### PR TITLE
Add support for 1Password CLI app integration

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,9 +7,30 @@ on:
     branches: [ "develop" ]
 
 jobs:
+  has:
+    name: Check Secrets
+    runs-on: ubuntu-latest
+    steps:
+      - id: secrets
+        env:
+          OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
+          OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
+          OPT_ACCOUNT_NAME: ${{ secrets.OPT_ACCOUNT_NAME }}
+          OPT_ACCOUNT_PASSWORD: ${{ secrets.OPT_ACCOUNT_PASSWORD }}
+          OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
+          OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
+          OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
+        if: ${{ env.OPT_ACCOUNT_ADDRESS != '' && env.OPT_ACCOUNT_EMAIL != '' && env.OPT_ACCOUNT_NAME != '' && env.OPT_ACCOUNT_PASSWORD != '' && env.OPT_ACCOUNT_SECRET_KEY != '' && env.OPT_CREATE_TEST_USER != '' && env.OPT_TEST_USER_EMAIL != '' }}
+        run:
+          echo "::set-output name=secrets::1"
+    outputs:
+      secrets: ${{ steps.secrets.outputs.secrets }}
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: has
+    if: ${{ needs.has.outputs.secrets }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   has:
-    name: Check Secrets
+    name: Validate
     runs-on: ubuntu-latest
     steps:
-      - id: secrets
+      - name: Check secrets
         env:
           OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
           OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
@@ -20,17 +20,17 @@ jobs:
           OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
           OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
           OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
-        if: ${{ env.OPT_ACCOUNT_ADDRESS != '' && env.OPT_ACCOUNT_EMAIL != '' && env.OPT_ACCOUNT_NAME != '' && env.OPT_ACCOUNT_PASSWORD != '' && env.OPT_ACCOUNT_SECRET_KEY != '' && env.OPT_CREATE_TEST_USER != '' && env.OPT_TEST_USER_EMAIL != '' }}
-        run:
-          echo "::set-output name=secrets::1"
-    outputs:
-      secrets: ${{ steps.secrets.outputs.secrets }}
+        run: |
+          if [[ -n "$OPT_ACCOUNT_ADDRESS" && -n "$OPT_ACCOUNT_EMAIL" && -n "$OPT_ACCOUNT_NAME" && -n "$OPT_ACCOUNT_PASSWORD" && -n "$OPT_ACCOUNT_SECRET_KEY" && -n "$OPT_CREATE_TEST_USER" && -n "$OPT_TEST_USER_EMAIL" ]]; then
+            echo "HAS_SECRETS=false" >> "$GITHUB_ENV"
+          else
+            echo "HAS_SECRETS=false" >> "$GITHUB_ENV"
+          fi
 
   build:
     name: Build
     runs-on: ubuntu-latest
     needs: has
-    if: ${{ needs.has.outputs.secrets }}
     permissions:
       actions: read
       contents: read
@@ -40,24 +40,24 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Debug --no-restore
-    - name: Test
-      env:
-        OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
-        OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
-        OPT_ACCOUNT_NAME: ${{ secrets.OPT_ACCOUNT_NAME }}
-        OPT_ACCOUNT_PASSWORD: ${{ secrets.OPT_ACCOUNT_PASSWORD }}
-        OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
-        OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
-        OPT_RUN_LIVE_TESTS: false
-        OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
-      run: dotnet test --configuration Debug --no-build --verbosity normal
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Debug --no-restore
+      - name: Test
+        env:
+          OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
+          OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
+          OPT_ACCOUNT_NAME: ${{ secrets.OPT_ACCOUNT_NAME }}
+          OPT_ACCOUNT_PASSWORD: ${{ secrets.OPT_ACCOUNT_PASSWORD }}
+          OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
+          OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
+          OPT_RUN_LIVE_TESTS: ${{ env.HAS_SECRETS }}
+          OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
+        run: dotnet test --configuration Debug --no-build --verbosity normal

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,11 +7,11 @@ on:
     branches: [ "master" ]
 
 jobs:
-  has:
-    name: Check Secrets
+  validate:
+    name: Validate
     runs-on: ubuntu-latest
     steps:
-      - id: secrets
+      - name: Check secrets
         env:
           OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
           OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
@@ -20,17 +20,17 @@ jobs:
           OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
           OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
           OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
-        if: ${{ env.OPT_ACCOUNT_ADDRESS != '' && env.OPT_ACCOUNT_EMAIL != '' && env.OPT_ACCOUNT_NAME != '' && env.OPT_ACCOUNT_PASSWORD != '' && env.OPT_ACCOUNT_SECRET_KEY != '' && env.OPT_CREATE_TEST_USER != '' && env.OPT_TEST_USER_EMAIL != '' }}
-        run:
-          echo "::set-output name=secrets::1"
-    outputs:
-      secrets: ${{ steps.secrets.outputs.secrets }}
+        run: |
+          if [[ -n "$OPT_ACCOUNT_ADDRESS" && -n "$OPT_ACCOUNT_EMAIL" && -n "$OPT_ACCOUNT_NAME" && -n "$OPT_ACCOUNT_PASSWORD" && -n "$OPT_ACCOUNT_SECRET_KEY" && -n "$OPT_CREATE_TEST_USER" && -n "$OPT_TEST_USER_EMAIL" ]]; then
+            echo "HAS_SECRETS=true" >> "$GITHUB_ENV"
+          else
+            echo "HAS_SECRETS=false" >> "$GITHUB_ENV"
+          fi
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: has
-    if: ${{ needs.has.outputs.secrets }}
+    needs: validate
     permissions:
       actions: read
       contents: read
@@ -40,30 +40,30 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: 'csharp'
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      env:
-        OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
-        OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
-        OPT_ACCOUNT_NAME: ${{ secrets.OPT_ACCOUNT_NAME }}
-        OPT_ACCOUNT_PASSWORD: ${{ secrets.OPT_ACCOUNT_PASSWORD }}
-        OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
-        OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
-        OPT_RUN_LIVE_TESTS: true
-        OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
-      run: dotnet test --configuration Release --no-build --verbosity normal
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2     
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: 'csharp'
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        env:
+          OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
+          OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
+          OPT_ACCOUNT_NAME: ${{ secrets.OPT_ACCOUNT_NAME }}
+          OPT_ACCOUNT_PASSWORD: ${{ secrets.OPT_ACCOUNT_PASSWORD }}
+          OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
+          OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
+          OPT_RUN_LIVE_TESTS: ${{ env.HAS_SECRETS }}
+          OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
+        run: dotnet test --configuration Release --no-build --verbosity normal
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,9 +7,30 @@ on:
     branches: [ "master" ]
 
 jobs:
+  has:
+    name: Check Secrets
+    runs-on: ubuntu-latest
+    steps:
+      - id: secrets
+        env:
+          OPT_ACCOUNT_ADDRESS: ${{ secrets.OPT_ACCOUNT_ADDRESS }}
+          OPT_ACCOUNT_EMAIL: ${{ secrets.OPT_ACCOUNT_EMAIL }}
+          OPT_ACCOUNT_NAME: ${{ secrets.OPT_ACCOUNT_NAME }}
+          OPT_ACCOUNT_PASSWORD: ${{ secrets.OPT_ACCOUNT_PASSWORD }}
+          OPT_ACCOUNT_SECRET_KEY: ${{ secrets.OPT_ACCOUNT_SECRET_KEY }}
+          OPT_CREATE_TEST_USER: ${{ secrets.OPT_CREATE_TEST_USER }}
+          OPT_TEST_USER_EMAIL: ${{ secrets.OPT_TEST_USER_EMAIL }}
+        if: ${{ env.OPT_ACCOUNT_ADDRESS != '' && env.OPT_ACCOUNT_EMAIL != '' && env.OPT_ACCOUNT_NAME != '' && env.OPT_ACCOUNT_PASSWORD != '' && env.OPT_ACCOUNT_SECRET_KEY != '' && env.OPT_CREATE_TEST_USER != '' && env.OPT_TEST_USER_EMAIL != '' }}
+        run:
+          echo "::set-output name=secrets::1"
+    outputs:
+      secrets: ${{ steps.secrets.outputs.secrets }}
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: has
+    if: ${{ needs.has.outputs.secrets }}
     permissions:
       actions: read
       contents: read

--- a/OnePassword.NET.Tests/SetUpAccount.cs
+++ b/OnePassword.NET.Tests/SetUpAccount.cs
@@ -3,63 +3,38 @@ using OnePassword.Common;
 
 namespace OnePassword;
 
-[TestFixture, Order(1)]
+[TestFixture]
+[Order(1)]
 public class SetUpAccount : TestsBase
 {
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void AddAccount()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.AddAccount(AccountAddress, AccountEmail, AccountSecretKey, AccountPassword);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.SetUp, () => { OnePassword.AddAccount(AccountAddress, AccountEmail, AccountSecretKey, AccountPassword); });
     }
 
-    [Test, Order(2)]
+    [Test]
+    [Order(2)]
     public void SignIn()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.SignIn(AccountPassword);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.SetUp, () => { OnePassword.SignIn(AccountPassword); });
     }
 
-    [Test, Order(3)]
+    [Test]
+    [Order(3)]
     public void GetAccounts()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var accounts = OnePassword.GetAccounts();
 
@@ -75,27 +50,17 @@ public class SetUpAccount : TestsBase
                 Assert.That(account.Email, Is.EqualTo(AccountEmail));
                 Assert.That(account.Shorthand, Is.EqualTo(AccountAddress[..AccountAddress.IndexOf(".", StringComparison.Ordinal)]));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(4)]
+    [Test]
+    [Order(4)]
     public void GetAccount()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var account = OnePassword.GetAccount();
 
@@ -108,16 +73,6 @@ public class SetUpAccount : TestsBase
                 Assert.That(account.State, Is.EqualTo(State.Active));
                 Assert.That(account.Created, Is.Not.EqualTo(default));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 }

--- a/OnePassword.NET.Tests/SetUpGroup.cs
+++ b/OnePassword.NET.Tests/SetUpGroup.cs
@@ -3,7 +3,8 @@ using OnePassword.Groups;
 
 namespace OnePassword;
 
-[TestFixture, Order(3)]
+[TestFixture]
+[Order(3)]
 public class SetUpGroup : TestsBase
 {
     private const string InitialName = "Created Group";
@@ -12,14 +13,14 @@ public class SetUpGroup : TestsBase
     private const string FinalName = "Test Group";
     private const string FinalDescription = "Used for unit testing.";
 
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void CreateGroup()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             _initialGroup = OnePassword.CreateGroup(InitialName, InitialDescription);
 
@@ -34,50 +35,27 @@ public class SetUpGroup : TestsBase
                 Assert.That(_initialGroup.Updated, Is.Not.EqualTo(default));
                 Assert.That(_initialGroup.Permissions, Has.Count.EqualTo(0));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(2)]
+    [Test]
+    [Order(2)]
     public void EditGroup()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.EditGroup(_initialGroup, FinalName, FinalDescription);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.SetUp, () => { OnePassword.EditGroup(_initialGroup, FinalName, FinalDescription); });
     }
 
-    [Test, Order(3)]
+    [Test]
+    [Order(3)]
     public void GetGroups()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var groups = OnePassword.GetGroups();
 
@@ -92,27 +70,17 @@ public class SetUpGroup : TestsBase
             });
 
             TestGroup = group;
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(4)]
+    [Test]
+    [Order(4)]
     public void GetGroup()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var group = OnePassword.GetGroup(TestGroup);
 
@@ -127,16 +95,6 @@ public class SetUpGroup : TestsBase
                 Assert.That(group.Updated, Is.Not.EqualTo(default));
                 Assert.That(group.Permissions, Has.Count.EqualTo(0));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 }

--- a/OnePassword.NET.Tests/SetUpUser.cs
+++ b/OnePassword.NET.Tests/SetUpUser.cs
@@ -4,22 +4,22 @@ using OnePassword.Users;
 
 namespace OnePassword;
 
-[TestFixture, Order(2)]
+[TestFixture]
+[Order(2)]
 public class SetUpUser : TestsBase
 {
-    private const int ConfirmTimeout = 2 * 60 * 1000;
     private const string InitialName = "Created User";
     private UserDetails _initialUser = null!;
     private const string FinalName = "Test User";
 
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void ProvisionUser()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             _initialUser = OnePassword.ProvisionUser(InitialName, TestUserEmail, Language.English);
 
@@ -34,27 +34,17 @@ public class SetUpUser : TestsBase
                 Assert.That(_initialUser.Updated, Is.Not.EqualTo(default));
                 Assert.That(_initialUser.LastAuthentication, Is.EqualTo(null));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(2)]
+    [Test]
+    [Order(2)]
     public void ConfirmUser()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var currentState = State.Unknown;
             var stopWatch = Stopwatch.StartNew();
@@ -63,7 +53,7 @@ public class SetUpUser : TestsBase
                 if (SetUpCancellationTokenSource.IsCancellationRequested)
                     throw new OperationCanceledException();
 
-                if (stopWatch.ElapsedMilliseconds > ConfirmTimeout)
+                if (stopWatch.ElapsedMilliseconds > TestUserConfirmTimeout)
                     throw new TimeoutException();
 
                 Thread.Sleep(RateLimit * 10);
@@ -71,50 +61,27 @@ public class SetUpUser : TestsBase
             }
             stopWatch.Stop();
             OnePassword.ConfirmUser(_initialUser);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(3)]
+    [Test]
+    [Order(3)]
     public void EditUser()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.EditUser(_initialUser, FinalName, false);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.SetUp, () => { OnePassword.EditUser(_initialUser, FinalName, false); });
     }
 
-    [Test, Order(4)]
+    [Test]
+    [Order(4)]
     public void GetUsers()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var users = OnePassword.GetUsers();
 
@@ -132,27 +99,17 @@ public class SetUpUser : TestsBase
             });
 
             TestUser = user;
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(5)]
+    [Test]
+    [Order(5)]
     public void GetUser()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var user = OnePassword.GetUser(TestUser);
 
@@ -167,62 +124,26 @@ public class SetUpUser : TestsBase
                 Assert.That(user.Updated, Is.Not.EqualTo(default));
                 Assert.That(user.LastAuthentication, Is.EqualTo(null));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(6)]
+    [Test]
+    [Order(6)]
     public void SuspendUser()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.SuspendUser(TestUser, 1);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.SetUp, () => { OnePassword.SuspendUser(TestUser, 1); });
     }
 
-    [Test, Order(7)]
+    [Test]
+    [Order(7)]
     public void ReactivateUser()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.ReactivateUser(TestUser);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.SetUp, () => { OnePassword.ReactivateUser(TestUser); });
     }
 }

--- a/OnePassword.NET.Tests/SetUpVault.cs
+++ b/OnePassword.NET.Tests/SetUpVault.cs
@@ -3,7 +3,8 @@ using OnePassword.Vaults;
 
 namespace OnePassword;
 
-[TestFixture, Order(4)]
+[TestFixture]
+[Order(4)]
 public class SetUpVault : TestsBase
 {
     private const string InitialName = "Created Vault";
@@ -14,14 +15,14 @@ public class SetUpVault : TestsBase
     private const string FinalDescription = "Used for unit testing.";
     private const VaultIcon FinalIcon = VaultIcon.Airplane;
 
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void CreateVault()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             _initialVault = OnePassword.CreateVault(InitialName, InitialDescription, InitialIcon, true);
 
@@ -33,50 +34,27 @@ public class SetUpVault : TestsBase
                 Assert.That(_initialVault.Items, Is.EqualTo(0));
                 Assert.That(_initialVault.Created, Is.Not.EqualTo(default));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(2)]
+    [Test]
+    [Order(2)]
     public void EditVault()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.EditVault(_initialVault, FinalName, FinalDescription, FinalIcon, false);
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.SetUp, () => { OnePassword.EditVault(_initialVault, FinalName, FinalDescription, FinalIcon, false); });
     }
 
-    [Test, Order(3)]
+    [Test]
+    [Order(3)]
     public void GetVaults()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var vaults = OnePassword.GetVaults();
 
@@ -91,27 +69,17 @@ public class SetUpVault : TestsBase
             });
 
             TestVault = vault;
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(4)]
+    [Test]
+    [Order(4)]
     public void GetVault()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.SetUp, () =>
         {
             var vault = OnePassword.GetVault(TestVault);
 
@@ -123,16 +91,6 @@ public class SetUpVault : TestsBase
                 Assert.That(vault.Items, Is.EqualTo(0));
                 Assert.That(vault.Created, Is.Not.EqualTo(default));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 }

--- a/OnePassword.NET.Tests/TearDownAccount.cs
+++ b/OnePassword.NET.Tests/TearDownAccount.cs
@@ -2,53 +2,28 @@ using OnePassword.Common;
 
 namespace OnePassword;
 
-[TestFixture, Order(99)]
+[TestFixture]
+[Order(99)]
 public class TearDownAccount : TestsBase
 {
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void SignOut()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, TearDownCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.SignOut(true);
-        }
-        catch (Exception)
-        {
-            TearDownCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.TearDown, () => { OnePassword.SignOut(true); });
     }
 
-    [Test, Order(2)]
+    [Test]
+    [Order(2)]
     public void ForgetAccount()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, TearDownCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.ForgetAccount(true);
-        }
-        catch (Exception)
-        {
-            TearDownCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.TearDown, () => { OnePassword.ForgetAccount(true); });
         DoFinalTearDown = true;
     }
 }

--- a/OnePassword.NET.Tests/TearDownGroup.cs
+++ b/OnePassword.NET.Tests/TearDownGroup.cs
@@ -2,29 +2,17 @@ using OnePassword.Common;
 
 namespace OnePassword;
 
-[TestFixture, Order(97)]
+[TestFixture]
+[Order(97)]
 public class TearDownGroup : TestsBase
 {
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void DeleteGroup()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, TearDownCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.DeleteGroup(TestGroup);
-        }
-        catch (Exception)
-        {
-            TearDownCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.TearDown, () => { OnePassword.DeleteGroup(TestGroup); });
     }
 }

--- a/OnePassword.NET.Tests/TearDownUser.cs
+++ b/OnePassword.NET.Tests/TearDownUser.cs
@@ -2,29 +2,17 @@ using OnePassword.Common;
 
 namespace OnePassword;
 
-[TestFixture, Order(98)]
+[TestFixture]
+[Order(98)]
 public class TearDownUser : TestsBase
 {
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void DeleteUser()
     {
         if (!RunLiveTests || !CreateTestUser)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, TearDownCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.DeleteUser(TestUser);
-        }
-        catch (Exception)
-        {
-            TearDownCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.TearDown, () => { OnePassword.DeleteUser(TestUser); });
     }
 }

--- a/OnePassword.NET.Tests/TearDownVault.cs
+++ b/OnePassword.NET.Tests/TearDownVault.cs
@@ -2,29 +2,17 @@ using OnePassword.Common;
 
 namespace OnePassword;
 
-[TestFixture, Order(96)]
+[TestFixture]
+[Order(96)]
 public class TearDownVault : TestsBase
 {
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void DeleteVault()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, TearDownCancellationTokenSource.Token);
-        try
-        {
-            OnePassword.DeleteVault(TestVault);
-        }
-        catch (Exception)
-        {
-            TearDownCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        Run(RunType.TearDown, () => { OnePassword.DeleteVault(TestVault); });
     }
 }

--- a/OnePassword.NET.Tests/TestItems.cs
+++ b/OnePassword.NET.Tests/TestItems.cs
@@ -3,7 +3,8 @@ using OnePassword.Items;
 
 namespace OnePassword;
 
-[TestFixture, Order(6)]
+[TestFixture]
+[Order(6)]
 public class TestItems : TestsBase
 {
     private const string InitialTitle = "Created Item";
@@ -21,14 +22,14 @@ public class TestItems : TestsBase
     private const FieldType FinalType = FieldType.Concealed;
     private const string FinalValue = "Test Value";
 
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void CreateItem()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.Test, () =>
         {
             var template = TestTemplate.Clone();
             template.Title = InitialTitle;
@@ -54,27 +55,17 @@ public class TestItems : TestsBase
                 Assert.That(_initialItem.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Value, Is.EqualTo(InitialValue));
                 Assert.That(_initialItem.Fields.First(x => x.Section?.Label == DeleteSection && x.Label == DeleteField).Value, Is.EqualTo(DeleteValue));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(2)]
+    [Test]
+    [Order(2)]
     public void EditItem()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.Test, () =>
         {
             _initialItem.Title = FinalTitle;
             _initialItem.Fields.First(x => x.Label == "username").Value = FinalUsername;
@@ -94,27 +85,17 @@ public class TestItems : TestsBase
                 Assert.That(item.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Value, Is.EqualTo(FinalValue));
                 Assert.That(item.Fields.FirstOrDefault(x => x.Section?.Label == DeleteSection && x.Label == DeleteField), Is.Null);
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(3)]
+    [Test]
+    [Order(3)]
     public void GetItems()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.Test, () =>
         {
             var items = OnePassword.GetItems(TestVault);
 
@@ -129,27 +110,17 @@ public class TestItems : TestsBase
             });
 
             TestItem = item;
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(4)]
+    [Test]
+    [Order(4)]
     public void GetItem()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.Test, () =>
         {
             var item = OnePassword.GetItem(TestItem, TestVault);
 
@@ -162,16 +133,6 @@ public class TestItems : TestsBase
                 Assert.That(item.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Value, Is.EqualTo(FinalValue));
                 Assert.That(item.Fields.FirstOrDefault(x => x.Section?.Label == DeleteSection && x.Label == DeleteField), Is.Null);
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 }

--- a/OnePassword.NET.Tests/TestTemplates.cs
+++ b/OnePassword.NET.Tests/TestTemplates.cs
@@ -4,46 +4,37 @@ using OnePassword.Templates;
 
 namespace OnePassword;
 
-[TestFixture, Order(5)]
+[TestFixture]
+[Order(5)]
 public class TestTemplates : TestsBase
 {
     private ITemplate _template = null!;
 
-    [Test, Order(1)]
+    [Test]
+    [Order(1)]
     public void GetTemplates()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.Test, () =>
         {
             var templates = OnePassword.GetTemplates();
 
             Assert.That(templates, Has.Count.EqualTo(22));
 
             _template = templates.First(x => x.Name == "Login");
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(2)]
+    [Test]
+    [Order(2)]
     public void GetTemplatesName()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.Test, () =>
         {
             TestTemplate = OnePassword.GetTemplate(_template);
 
@@ -52,27 +43,17 @@ public class TestTemplates : TestsBase
                 Assert.That(TestTemplate.Name, Is.EqualTo(_template.Name));
                 Assert.That(TestTemplate.Category, Is.Not.EqualTo(Category.Unknown));
             });
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 
-    [Test, Order(3)]
+    [Test]
+    [Order(3)]
     public void GetTemplatesByEnum()
     {
         if (!RunLiveTests)
             Assert.Ignore();
 
-        SemaphoreSlim.Wait(CommandTimeout, SetUpCancellationTokenSource.Token);
-        try
+        Run(RunType.Test, () =>
         {
             foreach (var enumValue in Enum.GetValues(typeof(Category)))
             {
@@ -92,16 +73,6 @@ public class TestTemplates : TestsBase
 
                 Thread.Sleep(RateLimit);
             }
-        }
-        catch (Exception)
-        {
-            SetUpCancellationTokenSource.Cancel();
-            throw;
-        }
-        finally
-        {
-            Thread.Sleep(RateLimit);
-            SemaphoreSlim.Release();
-        }
+        });
     }
 }

--- a/OnePassword.NET.sln.DotSettings
+++ b/OnePassword.NET.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=OnePassword_002ENET_002ETests_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OnePassword.NET/OnePasswordManager.Accounts.cs
+++ b/OnePassword.NET/OnePasswordManager.Accounts.cs
@@ -104,6 +104,15 @@ public sealed partial class OnePasswordManager
     }
 
     /// <summary>
+    /// Signs into the account using 1Password app integration.
+    /// </summary>
+    public void SignIn()
+    {
+        const string command = "signin --force";
+        _ = Op(command);
+    }
+
+    /// <summary>
     /// Signs out of the account.
     /// </summary>
     /// <param name="all">When <see langword="true"/>, signs out of all accounts.</param>

--- a/OnePassword.NET/OnePasswordManager.cs
+++ b/OnePassword.NET/OnePasswordManager.cs
@@ -23,6 +23,7 @@ public sealed partial class OnePasswordManager
     private readonly bool _verbose;
     private string _account = "";
     private string _session = "";
+    private bool _appIntegrated;
 
     /// <summary>
     /// Initializes a new instance of <see cref="OnePasswordManager"/> for the specified 1Password CLI executable.
@@ -31,13 +32,14 @@ public sealed partial class OnePasswordManager
     /// <param name="executable">The name of the 1Password CLI executable.</param>
     /// <param name="verbose">When <see langword="true"/>, commands sent to the 1Password CLI executable are output to the console.</param>
     /// <exception cref="FileNotFoundException">Thrown when the 1Password CLI executable cannot be found.</exception>
-    public OnePasswordManager(string path = "", string executable = "op.exe", bool verbose = false)
+    public OnePasswordManager(string path = "", string executable = "op.exe", bool verbose = false, bool appIntegrated = false)
     {
         _opPath = path.Length > 0 ? Path.Combine(path, executable) : Path.Combine(Directory.GetCurrentDirectory(), executable);
         if (!File.Exists(_opPath))
             throw new FileNotFoundException($"The 1Password CLI executable ({executable}) was not found in folder \"{Path.GetDirectoryName(_opPath)}\".");
 
         _verbose = verbose;
+        _appIntegrated = appIntegrated;
 
         Version = GetVersion();
     }
@@ -117,21 +119,27 @@ public sealed partial class OnePasswordManager
 
     private string Op(string command, IEnumerable<string> input, bool returnError)
     {
-        var passAccount = !IsExcludedCommand(command, _excludedAccountCommands);
-        if (passAccount && _account.Length == 0)
-            throw new InvalidOperationException("Cannot execute command because account has not been set.");
-
-        var passSession = !IsExcludedCommand(command, _excludedSessionCommands);
-        if (passSession && _session.Length == 0)
-            throw new InvalidOperationException("Cannot execute command because account has not been signed in.");
-
         var arguments = command;
+
+        if (!_appIntegrated)
+        {
+            var passAccount = !IsExcludedCommand(command, _excludedAccountCommands);
+            if (passAccount && _account.Length == 0)
+                throw new InvalidOperationException("Cannot execute command because account has not been set.");
+
+            var passSession = !IsExcludedCommand(command, _excludedSessionCommands);
+            if (passSession && _session.Length == 0)
+                throw new InvalidOperationException("Cannot execute command because account has not been signed in.");
+
+            if (passAccount)
+                arguments += $" --account {_account}";
+            if (passSession)
+                arguments += $" --session {_session}";
+        }
+
         if (command != "--version")
-            arguments += " --format json --no-color";
-        if (passAccount)
-            arguments += $" --account {_account}";
-        if (passSession)
-            arguments += $" --session {_session}";
+        arguments += " --format json --no-color";
+
 
         if (_verbose)
             Console.WriteLine($"{Path.GetDirectoryName(_opPath)}>op {arguments}");

--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
 # OnePassword.NET - 1Password CLI Wrapper
-This library serves as a .NET wrapper for the [1Password](https://1password.com/) command-line tool op.exe ( [Download](https://app-updates.agilebits.com/product_history/CLI2) | [Documentation](https://developer.1password.com/docs/cli/reference) ).
+
+This library serves as a .NET wrapper for the [1Password](https://1password.com/) command-line tool
+op.exe ( [Download](https://app-updates.agilebits.com/product_history/CLI2) | [Documentation](https://developer.1password.com/docs/cli/reference) ).
 
 [![nuget](https://img.shields.io/nuget/v/OnePassword.NET)](https://www.nuget.org/packages/OnePassword.NET/)
 [![master](https://github.com/jscarle/OnePassword.NET/actions/workflows/master.yml/badge.svg)](https://github.com/jscarle/OnePassword.NET/actions/workflows/master.yml)
 [![develop](https://github.com/jscarle/OnePassword.NET/actions/workflows/develop.yml/badge.svg)](https://github.com/jscarle/OnePassword.NET/actions/workflows/develop.yml)
 
 ## References
+
 This library targets .NET 6.0 and .NET 7.0.
 
 ## Dependencies
+
 This library has no dependencies.
 
 ## Quick Start
 
 ### Creating an instance of the manager
+
 ```csharp
 var onePassword = new OnePasswordManager();
 ```
 
 ### Adding your account and signing in for the first time
+
 ```csharp
 var domain = "my.1password.com";
 var email = "your@email.com";
@@ -30,22 +36,26 @@ onePassword.SignIn(password);
 ```
 
 ### Signing in for subsequent connections
+
 ```csharp
 onePassword.UseAccount(domain);
 onePassword.SignIn(password);
 ```
 
 ### Getting all vaults
+
 ```csharp
 var vaults = onePassword.GetVaults();
 ```
 
 ### Selecting a specific vault
+
 ```csharp
 var vault = vaults.First(x => x.Name == "Private");
 ```
 
 ### Creating an item using a template
+
 ```csharp
 var serverTemplate = onePassword.GetTemplate(Category.Server);
 
@@ -56,39 +66,80 @@ serverTemplate.Fields.First(x => x.Label == "password").Value = "secretpass";
 var serverItem = onePassword.CreateItem(serverTemplate, vault);
 ```
 
-_Note: If you want to reuse the same template for several items, make sure you clone the instance to avoid reference issues._
+_Note: If you want to reuse the same template for several items, make sure you clone the instance to avoid reference
+issues._
+
 ```csharp
 var server1 = serverTemplate.Clone();
 var server2 = serverTemplate.Clone();
 ```
 
 ### Getting all items in a vault
+
 ```csharp
 var items = onePassword.GetItems(vault);
 ```
 
 ### Selecting a specific item
+
 ```csharp
 var item = items.First(x => x.Title == "Your Item's Title");
 ```
 
 ### Editing a specific item
+
 ```csharp
 item.Fields.First(x => x.Label == "password").Value = "newpass";
 onePassword.EditItem(item, vault);
 ```
 
 ### Archiving an item
+
 ```csharp
 onePassword.ArchiveItem(item, vault);
 ```
 
 ### Deleting an item
+
 ```csharp
 onePassword.DeleteItem(item, vault);
 ```
 
 ### Signing out
+
 ```csharp
 onePassword.SignOut();
 ```
+
+## Running tests
+
+Due to the fact that this library acts as a wrapper for the CLI and in order for tests to have any significant value,
+the majority of tests are integration tests which must run against an active 1Password account (preferably a Business
+account).
+
+### Effects on the active account
+
+The integration tests will sign in to the specified account, then create and update a test group, a test user
+(optional), and a test vault. Items will then be created and update in the test vault. Finally, the test vault, user,
+and group will be deleted. _Note: If the integration tests fail, test data may remain in the specified account._
+
+### Configuration
+
+The integration tests are configured using the environment variables which are prefixed with `OPT_` (**O**ne**P**assword
+**T**ests).
+Environment variables which are integers must contain only numbers and those which are booleans must contain `true` or
+`false` as a string.
+
+| Environment Variable          | Description                                                                   | Type   | Default Value         |
+|-------------------------------|-------------------------------------------------------------------------------|--------|-----------------------|
+| OPT_COMMAND_TIMEOUT           | The timeout (in minutes) for each CLI command.                                | int    | `2`                   |
+| OPT_RATE_LIMIT                | The rate (in milliseconds) at which commands are executed.                    | int    | `250`                 |
+| OPT_RUN_LIVE_TESTS            | Activates or deactivates integration tests.                                   | bool   | `false`               |
+| OPT_CREATE_TEST_USER          | Activates or deactivates the creation of the test user and its related tests. | bool   | `false`               |
+| OPT_ACCOUNT_ADDRESS           | The account address. Should be the host name only.                            | string |                       |
+| OPT_ACCOUNT_EMAIL             | The email to use when authenticating.                                         | string |                       |
+| OPT_ACCOUNT_NAME              | The account name. Used to test account related commands.                      | string |                       |
+| OPT_ACCOUNT_PASSWORD          | The password to use when authenticating.                                      | string |                       |
+| OPT_ACCOUNT_SECRET_KEY        | The secret key to use when authenticating.                                    | string |                       |
+| OPT_TEST_USER_EMAIL           | The test user's email address.                                                | string |                       |
+| OPT_TEST_USER_CONFIRM_TIMEOUT | The time (in minutes) to wait for manual confirmation of the test user.       | int    | `OPT_COMMAND_TIMEOUT` |


### PR DESCRIPTION
First, I'm not sure if I'm creating the pull request correctly. Feel free to close it if not and provide some guidelines.

I've only done minimal testing within my PowerShell module, but I think the revisions should not require any existing code changes for any consumers.

Here is my [OPassCliPS](https://github.com/thedavecarroll/OPassCliPS/tree/initial_development) repo if you wanted to check it out.

```powershell
Connect-OPAccount -Verbose
Get-OPSession | Format-List
```
```text
VERBOSE: Attempting to discover the path to 1Password CLI.
VERBOSE: Setting 1Password CLI Path session variable.
VERBOSE: Creating 1Password session with app integration.
VERBOSE: 1Password CLI Version: 2.12.0
VERBOSE: Signing into 1Password.
VERBOSE: Retrieving connected account.
VERBOSE: Creating module cache for vaults, items, and accounts.
VERBOSE: Cache creation time: 00:03:876

CliPath              : C:\Program Files\1Password CLI\op.exe
IsAppIntegrated      : True
IsAuthenticated      : True
AuthenticatedAccount : <my account>
```

```powershell
Connect-OPAccount -Domain $Domain -Email $Email -SecretKey $SecretKey -Password $Password -Verbose
Get-OPSession | Format-List
```
```text
VERBOSE: Attempting to discover the path to 1Password CLI.
VERBOSE: Setting 1Password CLI Path session variable.
VERBOSE: Creating 1Password session without app integration.
VERBOSE: Adding account for <email address>.
VERBOSE: 1Password CLI Version: 2.12.0
VERBOSE: Signing into 1Password.
VERBOSE: Retrieving connected account.
VERBOSE: Creating module cache for vaults, items, and accounts.
VERBOSE: Cache creation time: 00:01:964


CliPath              : C:\Program Files\1Password CLI\op.exe
IsAppIntegrated      : False
IsAuthenticated      : True
AuthenticatedAccount : <my account>
```