### PR TITLE
Always pass account when specified

### DIFF
--- a/OnePassword.NET/OnePasswordManager.cs
+++ b/OnePassword.NET/OnePasswordManager.cs
@@ -219,8 +219,10 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
             case Mode.Interactive:
             case Mode.AppIntegrated:
             default:
-                var passAccount = !(_mode == Mode.AppIntegrated || IsExcludedCommand(command, _excludedAccountCommands));
-                if (passAccount && _account.Length == 0)
+                var excluded = IsExcludedCommand(command, _excludedAccountCommands);
+                var requireAccount = _mode != Mode.AppIntegrated && !excluded;
+                var passAccount = _account.Length != 0 && !excluded;
+                if (requireAccount && !passAccount)
                     throw new InvalidOperationException("Cannot execute command because account has not been set.");
 
                 var passSession = !(_mode == Mode.AppIntegrated || IsExcludedCommand(command, _excludedSessionCommands));


### PR DESCRIPTION
Specifying an account for `op` is not only useful when required. In an app-integrated setup where you have multiple accounts configured (like the scenario of a company account and a private one), passing the account when provided is critical in resolving requests.

This change keeps existing behaviour of excluding the parameter from some commands and failing when an account is required, but not provided. Outside of that, the account parameter is now _always_ provided if set.

Example of use in app-integrated context:
```csharp
s_Manager = new OnePasswordManager (
	new OnePasswordManagerOptions
	{
		AppIntegrated = true,
		Path = kBinariesPath,
		Executable = "op"
	});

s_Manager.UseAccount (kAccountID);
```