### PR TITLE
including the UUID in templates

### DIFF
--- a/OnePassword.NET.Tests/TestTemplates.cs
+++ b/OnePassword.NET.Tests/TestTemplates.cs
@@ -55,15 +55,14 @@ public class TestTemplates : TestsBase
 
         Run(RunType.Test, () =>
         {
-            foreach (var enumValue in Enum.GetValues(typeof(Category)))
+            foreach (var enumValue in Enum.GetValues<Category>())
             {
-                var enumMember = (Category)enumValue;
-                if (enumMember is Category.Custom or Category.Unknown)
+                if (enumValue is Category.Custom or Category.Unknown)
                     continue;
 
-                var enumMemberString = enumMember.ToEnumString();
+                var enumMemberString = enumValue.ToEnumString();
 
-                var template = OnePassword.GetTemplate(enumMember);
+                var template = OnePassword.GetTemplate(enumValue);
 
                 Assert.Multiple(() =>
                 {

--- a/OnePassword.NET/Templates/ITemplate.cs
+++ b/OnePassword.NET/Templates/ITemplate.cs
@@ -6,6 +6,11 @@
 public interface ITemplate : IEquatable<ITemplate>, IComparable<ITemplate>, IComparable
 {
     /// <summary>
+    /// The template UUID.
+    /// </summary>
+    string UUID { get; }
+
+    /// <summary>
     /// The template name.
     /// </summary>
     string Name { get; }

--- a/OnePassword.NET/Templates/ITemplate.cs
+++ b/OnePassword.NET/Templates/ITemplate.cs
@@ -8,7 +8,7 @@ public interface ITemplate : IEquatable<ITemplate>, IComparable<ITemplate>, ICom
     /// <summary>
     /// The template UUID.
     /// </summary>
-    string UUID { get; }
+    string Uuid { get; }
 
     /// <summary>
     /// The template name.

--- a/OnePassword.NET/Templates/Template.cs
+++ b/OnePassword.NET/Templates/Template.cs
@@ -9,7 +9,7 @@ public sealed class Template : ItemBase, ITemplate, ICloneable
     /// <inheritdoc />
     [JsonInclude]
     [JsonPropertyName("uuid")]
-    public string UUID { get; internal set; } = "";
+    public string Uuid { get; internal set; } = "";
 
     /// <inheritdoc />
     [JsonInclude]
@@ -72,7 +72,7 @@ public sealed class Template : ItemBase, ITemplate, ICloneable
     public bool Equals(ITemplate? other)
     {
         if (other is null) return false;
-        return ReferenceEquals(this, other) || string.Equals(UUID, other.UUID, StringComparison.OrdinalIgnoreCase);
+        return ReferenceEquals(this, other) || string.Equals(Uuid, other.Uuid, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />
@@ -87,14 +87,14 @@ public sealed class Template : ItemBase, ITemplate, ICloneable
     public int CompareTo(ITemplate? other)
     {
         if (other is null) return 1;
-        return ReferenceEquals(this, other) ? 0 : string.Compare(UUID, other.UUID, StringComparison.Ordinal);
+        return ReferenceEquals(this, other) ? 0 : string.Compare(Uuid, other.Uuid, StringComparison.Ordinal);
     }
 
     /// <inheritdoc />
     public override int GetHashCode() =>
         // ReSharper disable once NonReadonlyMemberInGetHashCode
         // Name can only be set by internal methods.
-        StringComparer.OrdinalIgnoreCase.GetHashCode(UUID) + StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
+        StringComparer.OrdinalIgnoreCase.GetHashCode(Uuid) + StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
 
     /// <inheritdoc />
     object ICloneable.Clone() => Clone();

--- a/OnePassword.NET/Templates/Template.cs
+++ b/OnePassword.NET/Templates/Template.cs
@@ -8,6 +8,11 @@ public sealed class Template : ItemBase, ITemplate, ICloneable
 {
     /// <inheritdoc />
     [JsonInclude]
+    [JsonPropertyName("uuid")]
+    public string UUID { get; internal set; } = "";
+
+    /// <inheritdoc />
+    [JsonInclude]
     [JsonPropertyName("name")]
     public string Name { get; internal set; } = "";
 
@@ -67,7 +72,7 @@ public sealed class Template : ItemBase, ITemplate, ICloneable
     public bool Equals(ITemplate? other)
     {
         if (other is null) return false;
-        return ReferenceEquals(this, other) || string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
+        return ReferenceEquals(this, other) || string.Equals(UUID, other.UUID, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />
@@ -82,14 +87,14 @@ public sealed class Template : ItemBase, ITemplate, ICloneable
     public int CompareTo(ITemplate? other)
     {
         if (other is null) return 1;
-        return ReferenceEquals(this, other) ? 0 : string.Compare(Name, other.Name, StringComparison.Ordinal);
+        return ReferenceEquals(this, other) ? 0 : string.Compare(UUID, other.UUID, StringComparison.Ordinal);
     }
 
     /// <inheritdoc />
     public override int GetHashCode() =>
         // ReSharper disable once NonReadonlyMemberInGetHashCode
         // Name can only be set by internal methods.
-        StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
+        StringComparer.OrdinalIgnoreCase.GetHashCode(UUID) + StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
 
     /// <inheritdoc />
     object ICloneable.Clone() => Clone();

--- a/OnePassword.NET/Templates/TemplateInfo.cs
+++ b/OnePassword.NET/Templates/TemplateInfo.cs
@@ -5,11 +5,16 @@ public sealed class TemplateInfo : ITemplate
 {
     /// <inheritdoc />
     [JsonInclude]
+    [JsonPropertyName("uuid")]
+    public string UUID { get; internal set; } = "";
+
+    /// <inheritdoc />
+    [JsonInclude]
     [JsonPropertyName("name")]
     public string Name { get; internal set; } = "";
 
     /// <inheritdoc />
-    public override string ToString() => Name;
+    public override string ToString() => $"{Name} ({UUID})";
 
     /// <summary>Equality operator.</summary>
     /// <param name="a">The <see cref="TemplateInfo" /> object.</param>
@@ -54,7 +59,7 @@ public sealed class TemplateInfo : ITemplate
     public bool Equals(ITemplate? other)
     {
         if (other is null) return false;
-        return ReferenceEquals(this, other) || string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
+        return ReferenceEquals(this, other) || string.Equals(UUID, other.UUID, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />
@@ -69,14 +74,14 @@ public sealed class TemplateInfo : ITemplate
     public int CompareTo(ITemplate? other)
     {
         if (other is null) return 1;
-        return ReferenceEquals(this, other) ? 0 : string.Compare(Name, other.Name, StringComparison.Ordinal);
+        return ReferenceEquals(this, other) ? 0 : string.Compare(UUID, other.UUID, StringComparison.Ordinal);
     }
 
     /// <inheritdoc />
     public override int GetHashCode() =>
         // ReSharper disable once NonReadonlyMemberInGetHashCode
         // Name can only be set by internal methods.
-        StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
+        StringComparer.OrdinalIgnoreCase.GetHashCode(UUID) + StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
 
     private static int NullSafeCompareTo(TemplateInfo? a, ITemplate? b)
     {

--- a/OnePassword.NET/Templates/TemplateInfo.cs
+++ b/OnePassword.NET/Templates/TemplateInfo.cs
@@ -6,7 +6,7 @@ public sealed class TemplateInfo : ITemplate
     /// <inheritdoc />
     [JsonInclude]
     [JsonPropertyName("uuid")]
-    public string UUID { get; internal set; } = "";
+    public string Uuid { get; internal set; } = "";
 
     /// <inheritdoc />
     [JsonInclude]
@@ -14,7 +14,7 @@ public sealed class TemplateInfo : ITemplate
     public string Name { get; internal set; } = "";
 
     /// <inheritdoc />
-    public override string ToString() => $"{Name} ({UUID})";
+    public override string ToString() => Name;
 
     /// <summary>Equality operator.</summary>
     /// <param name="a">The <see cref="TemplateInfo" /> object.</param>
@@ -59,7 +59,7 @@ public sealed class TemplateInfo : ITemplate
     public bool Equals(ITemplate? other)
     {
         if (other is null) return false;
-        return ReferenceEquals(this, other) || string.Equals(UUID, other.UUID, StringComparison.OrdinalIgnoreCase);
+        return ReferenceEquals(this, other) || string.Equals(Uuid, other.Uuid, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />
@@ -74,14 +74,14 @@ public sealed class TemplateInfo : ITemplate
     public int CompareTo(ITemplate? other)
     {
         if (other is null) return 1;
-        return ReferenceEquals(this, other) ? 0 : string.Compare(UUID, other.UUID, StringComparison.Ordinal);
+        return ReferenceEquals(this, other) ? 0 : string.Compare(Uuid, other.Uuid, StringComparison.Ordinal);
     }
 
     /// <inheritdoc />
     public override int GetHashCode() =>
         // ReSharper disable once NonReadonlyMemberInGetHashCode
         // Name can only be set by internal methods.
-        StringComparer.OrdinalIgnoreCase.GetHashCode(UUID) + StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
+        StringComparer.OrdinalIgnoreCase.GetHashCode(Uuid) + StringComparer.OrdinalIgnoreCase.GetHashCode(Name);
 
     private static int NullSafeCompareTo(TemplateInfo? a, ITemplate? b)
     {


### PR DESCRIPTION
To be able to determine the template used for existing password items. There is a known issue in the one password op tool that does not allow editing of password items based on custom templates. The workaround is to create a new item based on the source item and fill the fields and other properties and store that item. Afterwards deleting the old item. 