### PR TITLE
Add Support for Referencing Files Object in Item Class

### DIFF
--- a/OnePassword.NET/Items/File.cs
+++ b/OnePassword.NET/Items/File.cs
@@ -1,0 +1,45 @@
+﻿using OnePassword.Common;
+
+namespace OnePassword.Items;
+
+/// <summary>Represents a file object.</summary>
+public sealed class File : ITracked
+{
+    /// <summary>The file section.</summary>
+    [JsonInclude]
+    [JsonPropertyName("section")]
+    public Section? Section { get; internal set; }
+
+    /// <summary>The file ID.</summary>
+    [JsonInclude]
+    [JsonPropertyName("id")]
+    public string Id { get; internal set; } = "";
+
+    /// <summary>The name of file.</summary>
+    [JsonInclude]
+    [JsonPropertyName("name")]
+    public string Name { get; internal set; } = "";
+
+    /// <summary>The file size.</summary>
+    [JsonInclude]
+    [JsonPropertyName("size")]
+    public int Size { get; internal set; }
+
+    /// <summary>The content path.</summary>
+    [JsonInclude]
+    [JsonPropertyName("content_path")]
+    public string ContentPath { get; internal set; } = "";
+
+    /// <inheritdoc />
+    public bool Changed => false;
+
+    /// <summary>Initializes a new instance of <see cref="File" />.</summary>
+    public File()
+    {
+    }
+
+    /// <inheritdoc />
+    void ITracked.AcceptChanges()
+    {
+    }
+}

--- a/OnePassword.NET/Items/ItemBase.cs
+++ b/OnePassword.NET/Items/ItemBase.cs
@@ -76,6 +76,13 @@ public abstract class ItemBase : ITracked
     public TrackedList<string> Tags { get; internal set; } = [];
 
     /// <summary>
+    /// The files associated with the item.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("files")]
+    public TrackedList<File> Files { get; internal set; } = [];
+
+    /// <summary>
     /// Returns <see langword="true" /> when the title has changed, <see langword="false" /> otherwise.
     /// </summary>
     internal bool TitleChanged { get; private set; }


### PR DESCRIPTION
### Motivation

I had to access information of attached files in an item.

### Description

A new `File` class has been added to represent the files associated with an item.

The `Item` class has been updated to include a `Files` property, allowing easy access to any files linked to an item.

I have not added the support for editing file objects.

### Note

Due to limitations in my local environment, I was unable to run the suite of tests or add new test cases for this feature. I would greatly appreciate it if someone with the appropriate setup could assist with testing or guide me through the process.

I kept the existing code style in the new code but I welcome any feedback or suggestions for improvement.

Thank you for your consideration.