### PR TITLE
feature: Netstandard2.1

### DIFF
--- a/OnePassword.NET.Tests/OnePassword.NET.Tests.csproj
+++ b/OnePassword.NET.Tests/OnePassword.NET.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/OnePassword.NET/Common/CommonExtensions.cs
+++ b/OnePassword.NET/Common/CommonExtensions.cs
@@ -12,7 +12,7 @@ internal static class CommonExtensions
     /// <returns>A string representation of the enum field.</returns>
     /// <exception cref="ArgumentNullException">Thrown when field is null.</exception>
     /// <exception cref="NotImplementedException">Thrown when field is not correctly annotated with a <see cref="EnumMemberAttribute" />.</exception>
-    [UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2090:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.",
+    [SuppressMessage("AssemblyLoadTrimming", "IL2090:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.",
         Justification = "https://github.com/dotnet/runtime/issues/97737")]
     internal static string ToEnumString<TField>(this TField field) where TField : Enum
     {

--- a/OnePassword.NET/Common/JsonStringEnumConverterEx.cs
+++ b/OnePassword.NET/Common/JsonStringEnumConverterEx.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Text.Json;
 
 namespace OnePassword.Common;
 
@@ -13,10 +14,10 @@ internal sealed class JsonStringEnumConverterEx<TEnum> : JsonConverter<TEnum> wh
     private readonly Dictionary<string, TEnum> _stringToEnum = [];
 
     /// <summary>Initializes a new instance of <see cref="JsonStringEnumConverterEx{TEnum}" />.</summary>
-    [UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2090:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.", Justification = "https://github.com/dotnet/runtime/issues/97737")]
+    [SuppressMessage("AssemblyLoadTrimming", "IL2090:'this' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to 'target method'.", Justification = "https://github.com/dotnet/runtime/issues/97737")]
     public JsonStringEnumConverterEx()
     {
-        foreach (var enumMemberValue in Enum.GetValues<TEnum>())
+        foreach (TEnum enumMemberValue in Enum.GetValues(typeof(TEnum)))
         {
             var enumMemberName = enumMemberValue.ToString();
 

--- a/OnePassword.NET/OnePassword.NET.csproj
+++ b/OnePassword.NET/OnePassword.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <RootNamespace>OnePassword</RootNamespace>
         <AssemblyName>OnePassword.NET</AssemblyName>
         <PackageId>OnePassword.NET</PackageId>
@@ -35,11 +35,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Using Include="System.Collections.Immutable"/>
-        <Using Include="System.Text.Json"/>
-        <Using Include="System.Text.Json.Serialization"/>
-        <Using Include="System.Runtime.Serialization"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="System.Collections.Immutable" Version="9.0.4" />
+        <Using Include="System.Collections.Immutable" />
+        <Using Include="System.Text.Json.Serialization" />
+        <Using Include="System.Runtime.Serialization" />
+        <PackageReference Include="System.Text.Json" Version="6.0.11" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
         <None Include="..\LICENSE.md">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>

--- a/OnePassword.NET/OnePasswordManager.Items.cs
+++ b/OnePassword.NET/OnePasswordManager.Items.cs
@@ -1,4 +1,5 @@
-﻿using OnePassword.Common;
+﻿using System.Text.Json;
+using OnePassword.Common;
 using OnePassword.Items;
 using OnePassword.Templates;
 using OnePassword.Vaults;

--- a/OnePassword.NET/OnePasswordManager.cs
+++ b/OnePassword.NET/OnePasswordManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.IO.Compression;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
 using OnePassword.Common;

--- a/OnePassword.NET/Templates/Template.cs
+++ b/OnePassword.NET/Templates/Template.cs
@@ -1,4 +1,5 @@
-﻿using OnePassword.Common;
+﻿using System.Text.Json;
+using OnePassword.Common;
 using OnePassword.Items;
 
 namespace OnePassword.Templates;


### PR DESCRIPTION
## Summary

This PR adds support for `netstandard2.1` as requested.

## Changes

- Sets the target framework of the main library to `netstandard2.1`.
- Adds an explicit reference to `System.Text.Json` version `6.0.11` (compatible with `netstandard2.1`).
- Adds an explicit reference to `System.Collections.Immutable` version `9.0.4`.
- Replaces `UnconditionalSuppressMessage` with `SuppressMessage` due to visibility constraints in `netstandard2.1`.
- Updates the test project to target `net8.0` (required to support `System.Collections.Immutable 9.0.4`).
