### PR TITLE
Restore the single-email share overloads

### DIFF
--- a/NEXT_RELEASE.md
+++ b/NEXT_RELEASE.md
@@ -3,7 +3,6 @@
 ## Breaking changes
 
 - `ShareItem(...)` now returns `ItemShareResult` instead of `void`.
-- The single-email `ShareItem(...)` overloads were removed. Use a collection of email addresses for restricted links, or omit the collection entirely for unrestricted links.
 
 ## Highlights
 
@@ -24,6 +23,6 @@ onePassword.ShareItem(item, vault, "recipient@example.com");
 After:
 
 ```csharp
-var restrictedShare = onePassword.ShareItem(item, vault, new[] { "recipient@example.com" });
+var restrictedShare = onePassword.ShareItem(item, vault, "recipient@example.com");
 var unrestrictedShare = onePassword.ShareItem(item, vault);
 ```

--- a/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
+++ b/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
@@ -84,7 +84,33 @@ public class OnePasswordManagerCommandTests
     }
 
     [Test]
-    public void ShareItemWithSingleEmailUsesEmailsFlag()
+    public void ShareItemStringSingleEmailOverloadUsesEmailsFlag()
+    {
+        using var fakeCli = new FakeCli();
+        var manager = fakeCli.CreateManager();
+
+        var result = manager.ShareItem("item-id", "vault-id", "recipient@example.com");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.RawResponse, Is.EqualTo("{}"));
+            Assert.That(fakeCli.LastArguments, Does.Contain("--emails recipient@example.com"));
+        });
+    }
+
+    [Test]
+    public void ShareItemObjectSingleEmailOverloadUsesEmailsFlag()
+    {
+        using var fakeCli = new FakeCli();
+        var manager = fakeCli.CreateManager();
+
+        manager.ShareItem(new TestItem("item-id"), new TestVault("vault-id"), "recipient@example.com");
+
+        Assert.That(fakeCli.LastArguments, Does.Contain("--emails recipient@example.com"));
+    }
+
+    [Test]
+    public void ShareItemWithSingleEmailCollectionUsesEmailsFlag()
     {
         using var fakeCli = new FakeCli();
         var manager = fakeCli.CreateManager();

--- a/OnePassword.NET/IOnePasswordManager.Items.cs
+++ b/OnePassword.NET/IOnePasswordManager.Items.cs
@@ -148,6 +148,26 @@ public partial interface IOnePasswordManager
     /// <summary>Shares an item.</summary>
     /// <param name="item">The item to share.</param>
     /// <param name="vault">The vault that contains the item to share.</param>
+    /// <param name="emailAddress">The recipient email address.</param>
+    /// <param name="expiresIn">The delay before the link expires.</param>
+    /// <param name="viewOnce">Expires the link after a single view.</param>
+    /// <returns>The created share result.</returns>
+    /// <exception cref="ArgumentException">Thrown when there is an invalid argument.</exception>
+    public ItemShareResult ShareItem(IItem item, IVault vault, string emailAddress, TimeSpan? expiresIn = null, bool? viewOnce = null);
+
+    /// <summary>Shares an item.</summary>
+    /// <param name="itemId">The ID of the item to share.</param>
+    /// <param name="vaultId">The ID of the vault that contains the item to share.</param>
+    /// <param name="emailAddress">The recipient email address.</param>
+    /// <param name="expiresIn">The delay before the link expires.</param>
+    /// <param name="viewOnce">Expires the link after a single view.</param>
+    /// <returns>The created share result.</returns>
+    /// <exception cref="ArgumentException">Thrown when there is an invalid argument.</exception>
+    public ItemShareResult ShareItem(string itemId, string vaultId, string emailAddress, TimeSpan? expiresIn = null, bool? viewOnce = null);
+
+    /// <summary>Shares an item.</summary>
+    /// <param name="item">The item to share.</param>
+    /// <param name="vault">The vault that contains the item to share.</param>
     /// <param name="emailAddresses">The recipient email addresses. Leave <see langword="null" /> or empty to create an unrestricted share link.</param>
     /// <param name="expiresIn">The delay before the link expires.</param>
     /// <param name="viewOnce">Expires the link after a single view.</param>

--- a/OnePassword.NET/OnePasswordManager.Items.cs
+++ b/OnePassword.NET/OnePasswordManager.Items.cs
@@ -250,6 +250,38 @@ public sealed partial class OnePasswordManager
     }
 
     /// <inheritdoc />
+    public ItemShareResult ShareItem(IItem item, IVault vault, string emailAddress, TimeSpan? expiresIn = null, bool? viewOnce = null)
+    {
+        if (item is null || item.Id.Length == 0)
+            throw new ArgumentException($"{nameof(item.Id)} cannot be empty.", nameof(item));
+        if (vault is null || vault.Id.Length == 0)
+            throw new ArgumentException($"{nameof(vault.Id)} cannot be empty.", nameof(vault));
+        if (emailAddress is null || emailAddress.Length == 0)
+            throw new ArgumentException($"{nameof(emailAddress)} cannot be empty.", nameof(emailAddress));
+        var trimmedEmailAddress = emailAddress.Trim();
+        if (trimmedEmailAddress.Length == 0)
+            throw new ArgumentException($"{nameof(trimmedEmailAddress)} cannot be empty.", nameof(emailAddress));
+
+        return ShareItem(item.Id, vault.Id, trimmedEmailAddress, expiresIn, viewOnce);
+    }
+
+    /// <inheritdoc />
+    public ItemShareResult ShareItem(string itemId, string vaultId, string emailAddress, TimeSpan? expiresIn = null, bool? viewOnce = null)
+    {
+        if (itemId is null || itemId.Length == 0)
+            throw new ArgumentException($"{nameof(itemId)} cannot be empty.", nameof(itemId));
+        if (vaultId is null || vaultId.Length == 0)
+            throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
+        if (emailAddress is null || emailAddress.Length == 0)
+            throw new ArgumentException($"{nameof(emailAddress)} cannot be empty.", nameof(emailAddress));
+        var trimmedEmailAddress = emailAddress.Trim();
+        if (trimmedEmailAddress.Length == 0)
+            throw new ArgumentException($"{nameof(trimmedEmailAddress)} cannot be empty.", nameof(emailAddress));
+
+        return ShareItem(itemId, vaultId, new[] { trimmedEmailAddress }, expiresIn, viewOnce);
+    }
+
+    /// <inheritdoc />
     public ItemShareResult ShareItem(IItem item, IVault vault, IReadOnlyCollection<string>? emailAddresses = null, TimeSpan? expiresIn = null, bool? viewOnce = null)
     {
         if (item is null || item.Id.Length == 0)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This library has no dependencies.
 ## Breaking changes for the next x.x.x release
 
 - `ShareItem(...)` now returns `ItemShareResult` instead of `void`.
-- The single-email `ShareItem(...)` overloads were removed. Pass a collection of email addresses for restricted links, or omit the collection entirely for unrestricted links.
 
 ## Quick start
 
@@ -144,9 +143,20 @@ Console.WriteLine(share.Url);
 var share = onePassword.ShareItem(
     item,
     vault,
-    new[] { "recipient@example.com" },
+    "recipient@example.com",
     expiresIn: TimeSpan.FromDays(7),
     viewOnce: true);
+
+Console.WriteLine(share.Url);
+```
+
+### Sharing an item with multiple email restrictions
+
+```csharp
+var share = onePassword.ShareItem(
+    item,
+    vault,
+    new[] { "recipient1@example.com", "recipient2@example.com" });
 
 Console.WriteLine(share.Url);
 ```

--- a/docfx/docs/quick-start.md
+++ b/docfx/docs/quick-start.md
@@ -1,6 +1,6 @@
 # Quick start
 
-> Starting with the next x.x.x release, `ShareItem(...)` returns `ItemShareResult` and the single-email overloads are removed. Pass a collection of email addresses for restricted links, or omit the collection entirely for unrestricted links.
+> Starting with the next x.x.x release, `ShareItem(...)` returns `ItemShareResult` instead of `void`.
 
 ### Creating an instance of the manager
 
@@ -122,9 +122,20 @@ Console.WriteLine(share.Url);
 var share = onePassword.ShareItem(
     item,
     vault,
-    new[] { "recipient@example.com" },
+    "recipient@example.com",
     expiresIn: TimeSpan.FromDays(7),
     viewOnce: true);
+
+Console.WriteLine(share.Url);
+```
+
+### Sharing an item with multiple email restrictions
+
+```csharp
+var share = onePassword.ShareItem(
+    item,
+    vault,
+    new[] { "recipient1@example.com", "recipient2@example.com" });
 
 Console.WriteLine(share.Url);
 ```


### PR DESCRIPTION
## Summary
- restore the single-email `ShareItem(...)` overloads while keeping the new `ItemShareResult` return type
- correct the README, quick-start, and draft release notes so they no longer claim those overloads were removed
- add explicit command tests for both string and object single-email overloads

## Testing
- `dotnet test OnePassword.NET.Tests\\OnePassword.NET.Tests.csproj -m:1`
- `dotnet build OnePassword.NET\\OnePassword.NET.csproj -m:1`