### PR TITLE
Prepare the 2.5.0 release

### DIFF
--- a/NEXT_RELEASE.md
+++ b/NEXT_RELEASE.md
@@ -1,4 +1,4 @@
-# Draft release description for x.x.x
+# Draft release description for 2.5.0
 
 ## Breaking changes
 

--- a/OnePassword.NET.Tests/AccountPreTests.cs
+++ b/OnePassword.NET.Tests/AccountPreTests.cs
@@ -105,7 +105,7 @@ public class AccountPreTests : TestsBase
                 Assert.That(account.Domain, Is.EqualTo(AccountAddress[..AccountAddress.IndexOf('.', StringComparison.Ordinal)]));
                 Assert.That(account.Type, Is.Not.EqualTo(AccountType.Unknown));
                 Assert.That(account.State, Is.EqualTo(State.Active));
-                Assert.That(account.Created, Is.Not.EqualTo(default));
+                Assert.That(account.Created, Is.Not.EqualTo(default(DateTimeOffset)));
             });
         });
     }

--- a/OnePassword.NET.Tests/OnePassword.NET.Tests.csproj
+++ b/OnePassword.NET.Tests/OnePassword.NET.Tests.csproj
@@ -9,11 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
-        <PackageReference Include="NUnit" Version="4.1.0"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.2.0"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
+        <PackageReference Include="NUnit" Version="4.5.1"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.12.0"/>
+        <PackageReference Include="coverlet.collector" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/OnePassword.NET.Tests/SetUpGroup.cs
+++ b/OnePassword.NET.Tests/SetUpGroup.cs
@@ -41,8 +41,8 @@ public class SetUpGroup : TestsBase
                 Assert.That(_initialGroup.Description, Is.EqualTo(InitialDescription));
                 Assert.That(_initialGroup.Type, Is.EqualTo(GroupType.User));
                 Assert.That(_initialGroup.State, Is.EqualTo(State.Inactive));
-                Assert.That(_initialGroup.Created, Is.Not.EqualTo(default));
-                Assert.That(_initialGroup.Updated, Is.Not.EqualTo(default));
+                Assert.That(_initialGroup.Created, Is.Not.EqualTo(default(DateTimeOffset)));
+                Assert.That(_initialGroup.Updated, Is.Not.EqualTo(default(DateTimeOffset)));
                 Assert.That(_initialGroup.Permissions, Has.Count.EqualTo(0));
             });
         });
@@ -107,8 +107,8 @@ public class SetUpGroup : TestsBase
                 Assert.That(group.Description, Is.EqualTo(FinalDescription));
                 Assert.That(group.Type, Is.EqualTo(GroupType.User));
                 Assert.That(group.State, Is.EqualTo(State.Active));
-                Assert.That(group.Created, Is.Not.EqualTo(default));
-                Assert.That(group.Updated, Is.Not.EqualTo(default));
+                Assert.That(group.Created, Is.Not.EqualTo(default(DateTimeOffset)));
+                Assert.That(group.Updated, Is.Not.EqualTo(default(DateTimeOffset)));
                 Assert.That(group.Permissions, Has.Count.EqualTo(0));
             });
         });

--- a/OnePassword.NET.Tests/SetUpUser.cs
+++ b/OnePassword.NET.Tests/SetUpUser.cs
@@ -40,9 +40,9 @@ public class SetUpUser : TestsBase
                 Assert.That(_initialUser.Email, Is.EqualTo(TestUserEmail));
                 Assert.That(_initialUser.Type, Is.EqualTo(UserType.Member));
                 Assert.That(_initialUser.State, Is.EqualTo(State.TransferPending));
-                Assert.That(_initialUser.Created, Is.Not.EqualTo(default));
-                Assert.That(_initialUser.Updated, Is.Not.EqualTo(default));
-                Assert.That(_initialUser.LastAuthentication, Is.EqualTo(null));
+                Assert.That(_initialUser.Created, Is.Not.EqualTo(default(DateTimeOffset)));
+                Assert.That(_initialUser.Updated, Is.Not.EqualTo(default(DateTimeOffset)));
+                Assert.That(_initialUser.LastAuthentication, Is.Null);
             });
         });
     }
@@ -138,9 +138,9 @@ public class SetUpUser : TestsBase
                 Assert.That(user.Email, Is.EqualTo(TestUserEmail));
                 Assert.That(user.Type, Is.EqualTo(UserType.Member));
                 Assert.That(user.State, Is.EqualTo(State.Active));
-                Assert.That(user.Created, Is.Not.EqualTo(default));
-                Assert.That(user.Updated, Is.Not.EqualTo(default));
-                Assert.That(user.LastAuthentication, Is.EqualTo(null));
+                Assert.That(user.Created, Is.Not.EqualTo(default(DateTimeOffset)));
+                Assert.That(user.Updated, Is.Not.EqualTo(default(DateTimeOffset)));
+                Assert.That(user.LastAuthentication, Is.Null);
             });
         });
     }

--- a/OnePassword.NET.Tests/SetUpVault.cs
+++ b/OnePassword.NET.Tests/SetUpVault.cs
@@ -32,7 +32,7 @@ public class SetUpVault : TestsBase
                 Assert.That(_initialVault.Name, Is.EqualTo(InitialName));
                 Assert.That(_initialVault.Type, Is.EqualTo(VaultType.User));
                 Assert.That(_initialVault.Items, Is.EqualTo(0));
-                Assert.That(_initialVault.Created, Is.Not.EqualTo(default));
+                Assert.That(_initialVault.Created, Is.Not.EqualTo(default(DateTimeOffset)));
             });
         });
     }
@@ -89,7 +89,7 @@ public class SetUpVault : TestsBase
                 Assert.That(vault.Name, Is.EqualTo(FinalName));
                 Assert.That(vault.Type, Is.EqualTo(VaultType.User));
                 Assert.That(vault.Items, Is.EqualTo(0));
-                Assert.That(vault.Created, Is.Not.EqualTo(default));
+                Assert.That(vault.Created, Is.Not.EqualTo(default(DateTimeOffset)));
             });
         });
     }

--- a/OnePassword.NET.Tests/TestItems.cs
+++ b/OnePassword.NET.Tests/TestItems.cs
@@ -64,7 +64,7 @@ public class TestItems : TestsBase
             {
                 Assert.That(_initialItem.Id, Is.Not.Empty);
                 Assert.That(_initialItem.Title, Is.EqualTo(InitialTitle));
-                Assert.That(_initialItem.Created, Is.Not.EqualTo(default));
+                Assert.That(_initialItem.Created, Is.Not.EqualTo(default(DateTimeOffset?)));
                 Assert.That(_initialItem.Fields.First(x => x.Label == "username").Value, Is.EqualTo(InitialUsername));
                 Assert.That(_initialItem.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Type, Is.EqualTo(InitialType));
                 Assert.That(_initialItem.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Value, Is.EqualTo(InitialValue));
@@ -100,7 +100,7 @@ public class TestItems : TestsBase
             {
                 Assert.That(item.Id, Is.Not.Empty);
                 Assert.That(item.Title, Is.EqualTo(FinalTitle));
-                Assert.That(item.Created, Is.Not.EqualTo(default));
+                Assert.That(item.Created, Is.Not.EqualTo(default(DateTimeOffset?)));
                 Assert.That(item.Fields.First(x => x.Label == "username").Value, Is.EqualTo(FinalUsername));
                 Assert.That(item.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Type, Is.EqualTo(FinalType));
                 Assert.That(item.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Value, Is.EqualTo(FinalValue));
@@ -220,7 +220,7 @@ public class TestItems : TestsBase
             {
                 Assert.That(item.Id, Is.Not.Empty);
                 Assert.That(item.Title, Is.EqualTo(FinalTitle));
-                Assert.That(item.Created, Is.Not.EqualTo(default));
+                Assert.That(item.Created, Is.Not.EqualTo(default(DateTimeOffset?)));
                 Assert.That(item.Fields.First(x => x.Label == "username").Value, Is.EqualTo(FinalUsername));
                 Assert.That(item.Fields.First(x => x.Section?.Label == EditSection && x.Label == EditField).Value, Is.EqualTo(FinalValue));
                 Assert.That(item.Fields.First(x => x.Label == AddedField).Value, Is.EqualTo(AddedValue));

--- a/OnePassword.NET/OnePassword.NET.csproj
+++ b/OnePassword.NET/OnePassword.NET.csproj
@@ -9,9 +9,9 @@
         <Company>Jean-Sebastien Carle</Company>
         <Product>OnePassword.NET</Product>
         <Description>1Password CLI Wrapper</Description>
-        <Version>2.4.4</Version>
-        <AssemblyVersion>2.4.4.0</AssemblyVersion>
-        <FileVersion>2.4.4.0</FileVersion>
+        <Version>2.5.0</Version>
+        <AssemblyVersion>2.5.0.0</AssemblyVersion>
+        <FileVersion>2.5.0.0</FileVersion>
         <Copyright>Copyright © Jean-Sebastien Carle 2021-2025</Copyright>
         <RepositoryUrl>https://github.com/jscarle/OnePassword.NET</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
@@ -35,12 +35,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Collections.Immutable" Version="9.0.4" />
+        <PackageReference Include="System.Collections.Immutable" Version="10.0.3" />
         <Using Include="System.Collections.Immutable" />
         <Using Include="System.Text.Json.Serialization" />
         <Using Include="System.Runtime.Serialization" />
-        <PackageReference Include="System.Text.Json" Version="6.0.11" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
         <None Include="..\LICENSE.md">
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This library targets .NET Standard 2.1.
 
 This library has no dependencies.
 
-## Breaking changes for the next x.x.x release
+## Breaking changes for 2.5.0
 
 - `ShareItem(...)` now returns `ItemShare` instead of `void`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,0 @@
-# TODO
-
-Current snapshot as of 2026-03-09.
-
-Historical debugging notes and completed issue/PR triage were removed from this file after the related work landed.
-
-There are no active engineering follow-up items currently tracked in this file.

--- a/docfx/docs/quick-start.md
+++ b/docfx/docs/quick-start.md
@@ -1,6 +1,6 @@
 # Quick start
 
-> Starting with the next x.x.x release, `ShareItem(...)` returns `ItemShare` instead of `void`.
+> Starting with 2.5.0, `ShareItem(...)` returns `ItemShare` instead of `void`.
 
 ### Creating an instance of the manager
 


### PR DESCRIPTION
## Summary
- remove TODO.md now that no tracked items remain there
- update the package version to 2.5.0 and refresh NuGet dependencies to the latest stable versions
- update the remaining x.x.x release references and adjust NUnit assertions required by the dependency upgrade

## Testing
- dotnet build OnePassword.NET.sln -c Release
- dotnet test OnePassword.NET.sln -c Release