### PR TITLE
Add OnePasswordManager environment variable support

### DIFF
--- a/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
+++ b/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
@@ -188,6 +188,46 @@ public class OnePasswordManagerCommandTests
     }
 
     [Test]
+    public void GetEnvironmentVariablesUsesTrimmedEnvironmentIdAndParsesOutput()
+    {
+        using var fakeCli = new FakeCli(nextOutput: "API_URL=https://example.com\nCONNECTION=Server=db;Password=secret=\nEMPTY=\n");
+        var manager = fakeCli.CreateManager();
+
+        var variables = manager.GetEnvironmentVariables("  env-id  ");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fakeCli.LastArguments, Is.EqualTo("environment read env-id"));
+            Assert.That(variables.Select(x => x.Name), Is.EqualTo(new[] { "API_URL", "CONNECTION", "EMPTY" }));
+            Assert.That(variables.Select(x => x.Value), Is.EqualTo(new[] { "https://example.com", "Server=db;Password=secret=", "" }));
+        });
+    }
+
+    [Test]
+    public void SaveEnvironmentVariablesUsesTrimmedEnvironmentIdAndWritesOutput()
+    {
+        using var fakeCli = new FakeCli(nextOutput: "API_URL=https://example.com\n");
+        var manager = fakeCli.CreateManager();
+        var outputPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        try
+        {
+            manager.SaveEnvironmentVariables("  env-id  ", outputPath);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fakeCli.LastArguments, Is.EqualTo("environment read env-id"));
+                Assert.That(File.ReadAllText(outputPath), Is.EqualTo("API_URL=https://example.com\n"));
+            });
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+                File.Delete(outputPath);
+        }
+    }
+
+    [Test]
     public void RevokeGroupPermissionsUsesVaultGroupCommand()
     {
         using var fakeCli = new FakeCli();

--- a/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
+++ b/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
@@ -14,6 +14,8 @@ namespace OnePassword;
 [TestFixture]
 public class OnePasswordManagerCommandTests
 {
+    private static readonly string[] EnvironmentVariableNames = ["API_URL", "CONNECTION", "EMPTY"];
+    private static readonly string[] EnvironmentVariableValues = ["https://example.com", "Server=db;Password=secret=", ""];
     private static readonly string[] ParsedRecipients = ["one@example.com", "two@example.com"];
 
     [Test]
@@ -198,8 +200,8 @@ public class OnePasswordManagerCommandTests
         Assert.Multiple(() =>
         {
             Assert.That(fakeCli.LastArguments, Is.EqualTo("environment read env-id"));
-            Assert.That(variables.Select(x => x.Name), Is.EqualTo(new[] { "API_URL", "CONNECTION", "EMPTY" }));
-            Assert.That(variables.Select(x => x.Value), Is.EqualTo(new[] { "https://example.com", "Server=db;Password=secret=", "" }));
+            Assert.That(variables.Select(x => x.Name), Is.EqualTo(EnvironmentVariableNames));
+            Assert.That(variables.Select(x => x.Value), Is.EqualTo(EnvironmentVariableValues));
         });
     }
 

--- a/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
+++ b/OnePassword.NET.Tests/OnePasswordManagerCommandTests.cs
@@ -169,6 +169,17 @@ public class OnePasswordManagerCommandTests
     }
 
     [Test]
+    public void GetSecretPassesReferenceWithSpacesAsSingleArgument()
+    {
+        using var fakeCli = new FakeCli();
+        var manager = fakeCli.CreateManager();
+
+        manager.GetSecret("op://vault/item/field with spaces");
+
+        Assert.That(fakeCli.LastArgumentLines, Does.Contain("op://vault/item/field with spaces"));
+    }
+
+    [Test]
     public void SaveSecretUsesTrimmedReference()
     {
         using var fakeCli = new FakeCli();
@@ -417,6 +428,19 @@ public class OnePasswordManagerCommandTests
     }
 
     [Test]
+    public void ShareItemPassesEmailValueWithSpacesAsSingleArgument()
+    {
+        using var fakeCli = new FakeCli();
+        var manager = fakeCli.CreateManager();
+
+        manager.ShareItem("item-id", "vault-id", ["recipient@example.com --view-once"]);
+
+        var emailFlagIndex = Array.IndexOf(fakeCli.LastArgumentLines, "--emails");
+        Assert.That(emailFlagIndex, Is.GreaterThanOrEqualTo(0));
+        Assert.That(fakeCli.LastArgumentLines[emailFlagIndex + 1], Is.EqualTo("recipient@example.com --view-once"));
+    }
+
+    [Test]
     public void ShareItemWithEmptyEmailCollectionOmitsEmailsFlag()
     {
         using var fakeCli = new FakeCli();
@@ -481,6 +505,7 @@ public class OnePasswordManagerCommandTests
     private sealed class FakeCli : IDisposable
     {
         private readonly string _argumentsPath;
+        private readonly string _argumentLinesPath;
         private readonly string _directoryPath;
         private readonly string _errorOutputPath;
         private readonly string _inputPath;
@@ -494,6 +519,7 @@ public class OnePasswordManagerCommandTests
         {
             _directoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             _argumentsPath = Path.Combine(_directoryPath, "last-arguments.txt");
+            _argumentLinesPath = Path.Combine(_directoryPath, "last-argument-lines.txt");
             _errorOutputPath = Path.Combine(_directoryPath, "error-output.txt");
             _inputPath = Path.Combine(_directoryPath, "last-input.txt");
             _nextOutputPath = Path.Combine(_directoryPath, "next-output.txt");
@@ -527,7 +553,9 @@ public class OnePasswordManagerCommandTests
 
         public string ExecutableName { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "op.cmd" : "op";
 
-        public string LastArguments => File.Exists(_argumentsPath) ? File.ReadAllText(_argumentsPath) : "";
+        public string LastArguments => File.Exists(_argumentsPath) ? File.ReadAllText(_argumentsPath).TrimEnd('\r', '\n') : "";
+
+        public string[] LastArgumentLines => File.Exists(_argumentLinesPath) ? File.ReadAllLines(_argumentLinesPath) : [];
 
         public string LastInput => File.Exists(_inputPath) ? File.ReadAllText(_inputPath) : "";
 
@@ -571,6 +599,16 @@ public class OnePasswordManagerCommandTests
                   @echo off
                   setlocal
                   > "%~dp0last-arguments.txt" echo %*
+                  break > "%~dp0last-argument-lines.txt"
+                  if not "%~1"=="" >> "%~dp0last-argument-lines.txt" echo(%~1
+                  if not "%~2"=="" >> "%~dp0last-argument-lines.txt" echo(%~2
+                  if not "%~3"=="" >> "%~dp0last-argument-lines.txt" echo(%~3
+                  if not "%~4"=="" >> "%~dp0last-argument-lines.txt" echo(%~4
+                  if not "%~5"=="" >> "%~dp0last-argument-lines.txt" echo(%~5
+                  if not "%~6"=="" >> "%~dp0last-argument-lines.txt" echo(%~6
+                  if not "%~7"=="" >> "%~dp0last-argument-lines.txt" echo(%~7
+                  if not "%~8"=="" >> "%~dp0last-argument-lines.txt" echo(%~8
+                  if not "%~9"=="" >> "%~dp0last-argument-lines.txt" echo(%~9
                   > "%~dp0last-input.txt" more
                   if "%~1"=="update" (
                     if exist "%~dp0update-payload.zip" copy /y "%~dp0update-payload.zip" "%~3\update-payload.zip" > nul
@@ -591,6 +629,7 @@ public class OnePasswordManagerCommandTests
                   #!/bin/sh
                   script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
                   printf '%s' "$*" > "$script_dir/last-arguments.txt"
+                  printf '%s\n' "$@" > "$script_dir/last-argument-lines.txt"
                   cat > "$script_dir/last-input.txt"
                   if [ "$1" = "update" ]; then
                     if [ -f "$script_dir/update-payload.zip" ]; then

--- a/OnePassword.NET/Environments/EnvironmentVariable.cs
+++ b/OnePassword.NET/Environments/EnvironmentVariable.cs
@@ -1,0 +1,28 @@
+namespace OnePassword.Environments;
+
+/// <summary>Represents a variable from a 1Password Environment.</summary>
+public sealed class EnvironmentVariable
+{
+    /// <summary>The variable name.</summary>
+    public string Name { get; internal set; } = "";
+
+    /// <summary>The variable value.</summary>
+    public string Value { get; internal set; } = "";
+
+    /// <summary>Initializes a new instance of <see cref="EnvironmentVariable" />.</summary>
+    public EnvironmentVariable()
+    {
+    }
+
+    /// <summary>Initializes a new instance of <see cref="EnvironmentVariable" /> with the specified name and value.</summary>
+    /// <param name="name">The variable name.</param>
+    /// <param name="value">The variable value.</param>
+    public EnvironmentVariable(string name, string value)
+    {
+        Name = name ?? "";
+        Value = value ?? "";
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => $"{Name}={Value}";
+}

--- a/OnePassword.NET/IOnePasswordManager.Environments.cs
+++ b/OnePassword.NET/IOnePasswordManager.Environments.cs
@@ -1,0 +1,19 @@
+using OnePassword.Environments;
+
+namespace OnePassword;
+
+public partial interface IOnePasswordManager
+{
+    /// <summary>Gets the environment variables for a 1Password Environment.</summary>
+    /// <param name="environmentId">The Environment ID.</param>
+    /// <returns>The environment variables.</returns>
+    /// <exception cref="ArgumentException">Thrown when there is an invalid argument.</exception>
+    public ImmutableList<EnvironmentVariable> GetEnvironmentVariables(string environmentId);
+
+    /// <summary>Saves the environment variables for a 1Password Environment to disk.</summary>
+    /// <param name="environmentId">The Environment ID.</param>
+    /// <param name="filePath">The output file path.</param>
+    /// <param name="fileMode">The file mode to use when creating the file.</param>
+    /// <exception cref="ArgumentException">Thrown when there is an invalid argument.</exception>
+    public void SaveEnvironmentVariables(string environmentId, string filePath, string? fileMode = null);
+}

--- a/OnePassword.NET/OnePassword.NET.csproj
+++ b/OnePassword.NET/OnePassword.NET.csproj
@@ -65,6 +65,9 @@
         <Compile Update="IOnePasswordManager.Documents.cs">
             <DependentUpon>OnePasswordManager.Documents.cs</DependentUpon>
         </Compile>
+        <Compile Update="IOnePasswordManager.Environments.cs">
+            <DependentUpon>OnePasswordManager.Environments.cs</DependentUpon>
+        </Compile>
         <Compile Update="IOnePasswordManager.Groups.cs">
             <DependentUpon>OnePasswordManager.Groups.cs</DependentUpon>
         </Compile>

--- a/OnePassword.NET/OnePassword.NET.csproj
+++ b/OnePassword.NET/OnePassword.NET.csproj
@@ -9,7 +9,7 @@
         <Company>Jean-Sebastien Carle</Company>
         <Product>OnePassword.NET</Product>
         <Description>1Password CLI Wrapper</Description>
-        <Version>2.5.0</Version>
+        <Version>2.5.0-daydream.1</Version>
         <AssemblyVersion>2.5.0.0</AssemblyVersion>
         <FileVersion>2.5.0.0</FileVersion>
         <Copyright>Copyright © Jean-Sebastien Carle 2021-2025</Copyright>

--- a/OnePassword.NET/OnePasswordManager.Accounts.cs
+++ b/OnePassword.NET/OnePasswordManager.Accounts.cs
@@ -20,7 +20,7 @@ public sealed partial class OnePasswordManager
         if (_mode == Mode.ServiceAccount)
             throw new InvalidOperationException($"{nameof(GetAccounts)} is not supported when using service accounts.");
 
-        const string command = "account list";
+        var command = new OpCommand("account", "list");
         return Op(JsonContext.Default.ImmutableListAccount, command);
     }
 
@@ -32,7 +32,9 @@ public sealed partial class OnePasswordManager
 
         var trimmedAccount = account?.Trim() ?? "";
 
-        var command = trimmedAccount.Length > 0 ? $"account get --account \"{trimmedAccount}\"" : "account get";
+        var command = new OpCommand("account", "get");
+        if (trimmedAccount.Length > 0)
+            command.Add("--account", trimmedAccount);
         return Op(JsonContext.Default.AccountDetails, command);
     }
 
@@ -68,9 +70,9 @@ public sealed partial class OnePasswordManager
 
         var trimmedShorthand = shorthand?.Trim() ?? "";
 
-        var command = $"account add --address \"{trimmedAddress}\" --email \"{trimmedEmail}\" --secret-key \"{trimmedSecretKey}\"";
+        var command = new OpCommand("account", "add", "--address", trimmedAddress, "--email", trimmedEmail, "--secret-key", trimmedSecretKey);
         if (trimmedShorthand.Length > 0)
-            command += $" --shorthand \"{trimmedShorthand}\"";
+            command.Add("--shorthand", trimmedShorthand);
 
         var result = Op(command, trimmedPassword, true);
         if (result.Contains("No saved device ID.", StringComparison.Ordinal))
@@ -115,7 +117,7 @@ public sealed partial class OnePasswordManager
                 throw new ArgumentException($"{nameof(password)} cannot be empty.", nameof(password));
         }
 
-        const string command = "signin --force --raw";
+        var command = new OpCommand("signin", "--force", "--raw");
         var result = Op(command, password?.Trim());
         _session = result.Trim();
     }
@@ -126,11 +128,11 @@ public sealed partial class OnePasswordManager
         if (_mode == Mode.ServiceAccount)
             throw new InvalidOperationException($"{nameof(SignOut)} is not supported when using service accounts.");
 
-        var command = "signout";
+        var command = new OpCommand("signout");
         if (all)
-            command += " --all";
+            command.Add("--all");
         else if (_account.Length > 0)
-            command += $" --account \"{_account}\"";
+            command.Add("--account", _account);
         Op(command);
         _session = "";
     }
@@ -146,8 +148,8 @@ public sealed partial class OnePasswordManager
         if (_session.Length > 0)
             SignOut(all);
 
-        var command = "account forget";
-        command += all ? " --all" : $" \"{_account}\"";
+        var command = new OpCommand("account", "forget");
+        command.Add(all ? "--all" : _account);
 
         var result = Op(command);
 

--- a/OnePassword.NET/OnePasswordManager.Documents.cs
+++ b/OnePassword.NET/OnePasswordManager.Documents.cs
@@ -21,7 +21,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"document list --vault {vaultId}";
+        var command = new OpCommand("document", "list", "--vault", vaultId);
         return Op(JsonContext.Default.ImmutableListDocumentDetails, command);
     }
 
@@ -40,11 +40,11 @@ public sealed partial class OnePasswordManager
         if (vaultId is not null && vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = "document list";
+        var command = new OpCommand("document", "list");
         if (vaultId is not null)
-            command += $" --vault {vaultId}";
+            command.Add("--vault", vaultId);
         if (includeArchive is not null && includeArchive.Value)
-            command += " --include-archive";
+            command.Add("--include-archive");
         return Op(JsonContext.Default.ImmutableListDocumentDetails, command);
     }
 
@@ -80,9 +80,9 @@ public sealed partial class OnePasswordManager
         var trimmedFileMode = fileMode?.Trim();
 
         // Not specifying --force will hang waiting for user input if the file exists.
-        var command = $"document get {documentId} --out-file \"{trimmedFilePath}\" --force --vault {vaultId}";
+        var command = new OpCommand("document", "get", documentId, "--out-file", trimmedFilePath, "--force", "--vault", vaultId);
         if (trimmedFileMode is not null)
-            command += $" --file-mode {trimmedFileMode}";
+            command.Add("--file-mode", trimmedFileMode);
         Op(command);
     }
 
@@ -119,13 +119,13 @@ public sealed partial class OnePasswordManager
         var trimmedFileMode = fileMode?.Trim();
 
         // Not specifying --force will hang waiting for user input if the file exists.
-        var command = $"document get {documentId} --out-file \"{trimmedFilePath}\" --force";
+        var command = new OpCommand("document", "get", documentId, "--out-file", trimmedFilePath, "--force");
         if (vaultId is not null)
-            command += $" --vault {vaultId}";
+            command.Add("--vault", vaultId);
         if (includeArchive is not null && includeArchive.Value)
-            command += " --include-archive";
+            command.Add("--include-archive");
         if (trimmedFileMode is not null)
-            command += $" --file-mode {trimmedFileMode}";
+            command.Add("--file-mode", trimmedFileMode);
         Op(command);
     }
 
@@ -177,13 +177,13 @@ public sealed partial class OnePasswordManager
         var trimmedFileName = fileName?.Trim();
         var trimmedTitle = title?.Trim();
 
-        var command = $"document create \"{trimmedFilePath}\" --vault {vaultId}";
+        var command = new OpCommand("document", "create", trimmedFilePath, "--vault", vaultId);
         if (trimmedFileName is not null)
-            command += $" --file-name \"{trimmedFileName}\"";
+            command.Add("--file-name", trimmedFileName);
         if (trimmedTitle is not null)
-            command += $" --title \"{trimmedTitle}\"";
+            command.Add("--title", trimmedTitle);
         if (tags is not null && tags.Count > 0)
-            command += $" --tags \"{tags.ToCommaSeparated()}\"";
+            command.Add("--tags", tags.ToCommaSeparated());
         return Op(JsonContext.Default.Document, command);
     }
 
@@ -223,13 +223,13 @@ public sealed partial class OnePasswordManager
         var trimmedFileName = fileName?.Trim();
         var trimmedTitle = title?.Trim();
 
-        var command = $"document edit {documentId} \"{trimmedFilePath}\" --vault {vaultId}";
+        var command = new OpCommand("document", "edit", documentId, trimmedFilePath, "--vault", vaultId);
         if (trimmedFileName is not null)
-            command += $" --file-name \"{trimmedFileName}\"";
+            command.Add("--file-name", trimmedFileName);
         if (trimmedTitle is not null)
-            command += $" --title \"{trimmedTitle}\"";
+            command.Add("--title", trimmedTitle);
         if (tags is not null && tags.Count > 0)
-            command += $" --tags \"{tags.ToCommaSeparated()}\"";
+            command.Add("--tags", tags.ToCommaSeparated());
         Op(command);
     }
 
@@ -252,7 +252,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"document delete {documentId} --vault {vaultId} --archive";
+        var command = new OpCommand("document", "delete", documentId, "--vault", vaultId, "--archive");
         Op(command);
     }
 
@@ -275,7 +275,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"document delete {documentId} --vault {vaultId}";
+        var command = new OpCommand("document", "delete", documentId, "--vault", vaultId);
         Op(command);
     }
 }

--- a/OnePassword.NET/OnePasswordManager.Environments.cs
+++ b/OnePassword.NET/OnePasswordManager.Environments.cs
@@ -1,0 +1,68 @@
+using OnePassword.Environments;
+
+namespace OnePassword;
+
+public sealed partial class OnePasswordManager
+{
+    /// <inheritdoc />
+    public ImmutableList<EnvironmentVariable> GetEnvironmentVariables(string environmentId)
+    {
+        var result = ReadEnvironmentVariables(environmentId);
+        return ParseEnvironmentVariables(result);
+    }
+
+    /// <inheritdoc />
+    public void SaveEnvironmentVariables(string environmentId, string filePath, string? fileMode = null)
+    {
+        ValidateEnvironmentId(environmentId);
+        if (filePath is null || filePath.Length == 0)
+            throw new ArgumentException($"{nameof(filePath)} cannot be empty.", nameof(filePath));
+        var trimmedFilePath = filePath.Trim();
+        if (trimmedFilePath.Length == 0)
+            throw new ArgumentException($"{nameof(trimmedFilePath)} cannot be empty.", nameof(filePath));
+
+        var trimmedFileMode = fileMode?.Trim();
+        var result = ReadEnvironmentVariables(environmentId);
+
+        File.WriteAllText(trimmedFilePath, result);
+        if (trimmedFileMode is not null && trimmedFileMode.Length > 0)
+            ApplyFileMode(trimmedFileMode, trimmedFilePath);
+    }
+
+    private string ReadEnvironmentVariables(string environmentId)
+    {
+        ValidateEnvironmentId(environmentId);
+        var trimmedEnvironmentId = environmentId.Trim();
+        var command = $"environment read {trimmedEnvironmentId}";
+        return Op(command, Array.Empty<string>(), false, false);
+    }
+
+    private static ImmutableList<EnvironmentVariable> ParseEnvironmentVariables(string result)
+    {
+        var variables = ImmutableList.CreateBuilder<EnvironmentVariable>();
+        using var reader = new StringReader(result);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (line.Length == 0)
+                continue;
+
+            var separatorIndex = line.IndexOf('=');
+            if (separatorIndex <= 0)
+                throw new SerializationException("Could not deserialize the command result.");
+
+            variables.Add(new EnvironmentVariable(line[..separatorIndex], line[(separatorIndex + 1)..]));
+        }
+
+        return variables.ToImmutable();
+    }
+
+    private static void ValidateEnvironmentId(string environmentId)
+    {
+        if (environmentId is null || environmentId.Length == 0)
+            throw new ArgumentException($"{nameof(environmentId)} cannot be empty.", nameof(environmentId));
+        var trimmedEnvironmentId = environmentId.Trim();
+        if (trimmedEnvironmentId.Length == 0)
+            throw new ArgumentException($"{nameof(trimmedEnvironmentId)} cannot be empty.", nameof(environmentId));
+    }
+}

--- a/OnePassword.NET/OnePasswordManager.Environments.cs
+++ b/OnePassword.NET/OnePasswordManager.Environments.cs
@@ -7,6 +7,7 @@ public sealed partial class OnePasswordManager
     /// <inheritdoc />
     public ImmutableList<EnvironmentVariable> GetEnvironmentVariables(string environmentId)
     {
+        ValidateEnvironmentId(environmentId);
         var result = ReadEnvironmentVariables(environmentId);
         return ParseEnvironmentVariables(result);
     }
@@ -47,7 +48,7 @@ public sealed partial class OnePasswordManager
             if (line.Length == 0)
                 continue;
 
-            var separatorIndex = line.IndexOf('=');
+            var separatorIndex = line.IndexOf('=', StringComparison.Ordinal);
             if (separatorIndex <= 0)
                 throw new SerializationException("Could not deserialize the command result.");
 

--- a/OnePassword.NET/OnePasswordManager.Environments.cs
+++ b/OnePassword.NET/OnePasswordManager.Environments.cs
@@ -34,7 +34,7 @@ public sealed partial class OnePasswordManager
     {
         ValidateEnvironmentId(environmentId);
         var trimmedEnvironmentId = environmentId.Trim();
-        var command = $"environment read {trimmedEnvironmentId}";
+        var command = new OpCommand("environment", "read", trimmedEnvironmentId);
         return Op(command, Array.Empty<string>(), false, false);
     }
 

--- a/OnePassword.NET/OnePasswordManager.Groups.cs
+++ b/OnePassword.NET/OnePasswordManager.Groups.cs
@@ -10,7 +10,7 @@ public sealed partial class OnePasswordManager
     /// <inheritdoc />
     public ImmutableList<Group> GetGroups()
     {
-        const string command = "group list";
+        var command = new OpCommand("group", "list");
         return Op(JsonContext.Default.ImmutableListGroup, command);
     }
 
@@ -38,7 +38,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"vault group list {vaultId}";
+        var command = new OpCommand("vault", "group", "list", vaultId);
         return Op(JsonContext.Default.ImmutableListVaultGroup, command);
     }
 
@@ -48,7 +48,7 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"group list --user {userId}";
+        var command = new OpCommand("group", "list", "--user", userId);
         return Op(JsonContext.Default.ImmutableListUserGroup, command);
     }
 
@@ -67,7 +67,7 @@ public sealed partial class OnePasswordManager
         if (groupId is null || groupId.Length == 0)
             throw new ArgumentException($"{nameof(groupId)} cannot be empty.", nameof(groupId));
 
-        var command = $"group get {groupId}";
+        var command = new OpCommand("group", "get", groupId);
         return Op(JsonContext.Default.GroupDetails, command);
     }
 
@@ -83,9 +83,9 @@ public sealed partial class OnePasswordManager
 
         var trimmedDescription = description?.Trim();
 
-        var command = $"group create \"{trimmedName}\"";
+        var command = new OpCommand("group", "create", trimmedName);
         if (trimmedDescription is not null)
-            command += $" --description \"{trimmedDescription}\"";
+            command.Add("--description", trimmedDescription);
         return Op(JsonContext.Default.GroupDetails, command);
     }
 
@@ -120,11 +120,11 @@ public sealed partial class OnePasswordManager
         if (name is null && description is null)
             throw new InvalidOperationException("Nothing to edit.");
 
-        var command = $"group edit {groupId}";
+        var command = new OpCommand("group", "edit", groupId);
         if (trimmedName is not null)
-            command += $" --name \"{trimmedName}\"";
+            command.Add("--name", trimmedName);
         if (trimmedDescription is not null)
-            command += $" --description \"{trimmedDescription}\"";
+            command.Add("--description", trimmedDescription);
         Op(command);
     }
 
@@ -143,7 +143,7 @@ public sealed partial class OnePasswordManager
         if (groupId is null || groupId.Length == 0)
             throw new ArgumentException($"{nameof(groupId)} cannot be empty.", nameof(groupId));
 
-        var command = $"group delete {groupId}";
+        var command = new OpCommand("group", "delete", groupId);
         Op(command);
     }
 
@@ -170,7 +170,7 @@ public sealed partial class OnePasswordManager
         if (userRole != UserRole.Member && userRole != UserRole.Manager)
             throw new ArgumentException($"{nameof(userRole)} must be {nameof(UserRole.Member)} or {nameof(UserRole.Manager)}.", nameof(userRole));
 
-        var command = $"group user grant --group {groupId} --user {userId} --role \"{userRole.ToEnumString()}\"";
+        var command = new OpCommand("group", "user", "grant", "--group", groupId, "--user", userId, "--role", userRole.ToEnumString());
         Op(command);
     }
 
@@ -193,7 +193,7 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"group user revoke --group {groupId} --user {userId}";
+        var command = new OpCommand("group", "user", "revoke", "--group", groupId, "--user", userId);
         Op(command);
     }
 }

--- a/OnePassword.NET/OnePasswordManager.Items.cs
+++ b/OnePassword.NET/OnePasswordManager.Items.cs
@@ -24,7 +24,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item list --vault {vaultId}";
+        var command = new OpCommand("item", "list", "--vault", vaultId);
         return Op(JsonContext.Default.ImmutableListItem, command);
     }
 
@@ -44,17 +44,17 @@ public sealed partial class OnePasswordManager
         if (vaultId is not null && vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = "item list";
+        var command = new OpCommand("item", "list");
         if (vaultId is not null)
-            command += $" --vault {vaultId}";
+            command.Add("--vault", vaultId);
         if (includeArchive is not null && includeArchive.Value)
-            command += " --include-archive";
+            command.Add("--include-archive");
         if (favorite is not null && favorite.Value)
-            command += " --favorite";
+            command.Add("--favorite");
         if (categories is not null && categories.Count > 0)
-            command += $" --categories \"{categories.ToCommaSeparated(true)}\"";
+            command.Add("--categories", categories.ToCommaSeparated(true));
         if (tags is not null && tags.Count > 0)
-            command += $" --tags \"{tags.ToCommaSeparated()}\"";
+            command.Add("--tags", tags.ToCommaSeparated());
         return Op(JsonContext.Default.ImmutableListItem, command);
     }
 
@@ -77,7 +77,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item get {itemId} --vault {vaultId}";
+        var command = new OpCommand("item", "get", itemId, "--vault", vaultId);
         return Op(JsonContext.Default.Item, command);
     }
 
@@ -100,11 +100,11 @@ public sealed partial class OnePasswordManager
         if (vaultId is not null && vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item get {itemId}";
+        var command = new OpCommand("item", "get", itemId);
         if (vaultId is not null)
-            command += $" --vault {vaultId}";
+            command.Add("--vault", vaultId);
         if (includeArchive is not null && includeArchive.Value)
-            command += " --include-archive";
+            command.Add("--include-archive");
         return Op(JsonContext.Default.Item, command);
     }
 
@@ -125,9 +125,9 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item create --vault {vaultId} -";
+        var command = new OpCommand("item", "create", "--vault", vaultId, "-");
         foreach (var assignmentStatement in GetFileAttachmentAssignmentStatements(template.Fields, template.FileAttachments))
-            command += $" {QuoteArgument(assignmentStatement)}";
+            command.Add(assignmentStatement);
 
         var json = SerializeTemplateForItemCommand(template);
         var createdItem = Op(JsonContext.Default.Item, command, json);
@@ -154,20 +154,20 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item edit {item.Id} --vault {vaultId}";
+        var command = new OpCommand("item", "edit", item.Id, "--vault", vaultId);
         foreach (var assignmentStatement in GetFileAttachmentAssignmentStatements(item.Fields, item.FileAttachments)
                      .Concat(GetDeletedFileAttachmentAssignmentStatements(item.FileAttachments)))
-            command += $" {QuoteArgument(assignmentStatement)}";
+            command.Add(assignmentStatement);
 
         var json = SerializeItemForEditCommand(item);
         if (item.TitleChanged)
-            command += $" --title \"{item.Title}\"";
+            command.Add("--title", item.Title);
         if (((ITracked)item.Tags).Changed)
-            command += $" --tags \"{item.Tags.ToCommaSeparated()}\"";
+            command.Add("--tags", item.Tags.ToCommaSeparated());
         if (((ITracked)item.Urls).Changed)
         {
             var changedUrl = item.Urls.FirstOrDefault(url => url.Primary && ((ITracked)url).Changed);
-            command += $" --url \"{changedUrl}\"";
+            command.Add("--url", $"{changedUrl}");
         }
         var editedItem = Op(JsonContext.Default.Item, command, json);
         ((ITracked)item).AcceptChanges();
@@ -233,7 +233,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item delete {itemId} --vault {vaultId} --archive";
+        var command = new OpCommand("item", "delete", itemId, "--vault", vaultId, "--archive");
         Op(command);
     }
 
@@ -256,7 +256,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item delete {itemId} --vault {vaultId}";
+        var command = new OpCommand("item", "delete", itemId, "--vault", vaultId);
         Op(command);
     }
 
@@ -283,7 +283,7 @@ public sealed partial class OnePasswordManager
         if (destinationVaultId is null || destinationVaultId.Length == 0)
             throw new ArgumentException($"{nameof(destinationVaultId)} cannot be empty.", nameof(destinationVaultId));
 
-        var command = $"item move {itemId} --current-vault {currentVaultId} --destination-vault {destinationVaultId}";
+        var command = new OpCommand("item", "move", itemId, "--current-vault", currentVaultId, "--destination-vault", destinationVaultId);
         Op(command);
     }
 
@@ -338,14 +338,14 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"item share {itemId} --vault {vaultId}";
+        var command = new OpCommand("item", "share", itemId, "--vault", vaultId);
         var normalizedEmailAddresses = NormalizeEmailAddresses(emailAddresses);
         if (normalizedEmailAddresses.Count > 0)
-            command += $" --emails {string.Join(',', normalizedEmailAddresses)}";
+            command.Add("--emails", string.Join(',', normalizedEmailAddresses));
         if (expiresIn is not null)
-            command += $" --expires-in {expiresIn.Value.ToHumanReadable()}";
+            command.Add("--expires-in", expiresIn.Value.ToHumanReadable());
         if (viewOnce is not null && viewOnce.Value)
-            command += " --view-once";
+            command.Add("--view-once");
         return ParseItemShare(Op(command));
     }
 
@@ -529,11 +529,6 @@ public sealed partial class OnePasswordManager
         }
 
         return trimmedSection.Length == 0 ? trimmedName : $"{trimmedSection}.{trimmedName}";
-    }
-
-    private static string QuoteArgument(string argument)
-    {
-        return $"\"{argument.Replace("\"", "\\\"", StringComparison.InvariantCulture)}\"";
     }
 
     private static ItemShare ParseItemShare(string result)

--- a/OnePassword.NET/OnePasswordManager.Templates.cs
+++ b/OnePassword.NET/OnePasswordManager.Templates.cs
@@ -9,7 +9,7 @@ public sealed partial class OnePasswordManager
     /// <inheritdoc />
     public ImmutableList<TemplateInfo> GetTemplates()
     {
-        const string command = "item template list";
+        var command = new OpCommand("item", "template", "list");
         return Op(JsonContext.Default.ImmutableListTemplateInfo, command);
     }
 
@@ -19,7 +19,7 @@ public sealed partial class OnePasswordManager
         if (template is null || template.Name.Length == 0)
             throw new ArgumentException($"{nameof(template.Name)} cannot be empty.", nameof(template));
 
-        var command = $"item template get \"{template.Name}\"";
+        var command = new OpCommand("item", "template", "get", template.Name);
         var result = Op(JsonContext.Default.Template, command);
 
         result.Name = template.Name;
@@ -33,7 +33,7 @@ public sealed partial class OnePasswordManager
         if (string.IsNullOrEmpty(name))
             throw new ArgumentException($"{nameof(name)} cannot be empty.", nameof(name));
 
-        var command = $"item template get \"{name}\"";
+        var command = new OpCommand("item", "template", "get", name);
         var result = Op(JsonContext.Default.Template, command);
 
         result.Name = name;
@@ -49,7 +49,7 @@ public sealed partial class OnePasswordManager
 
         var templateName = category.ToEnumString();
 
-        var command = $"item template get \"{templateName}\"";
+        var command = new OpCommand("item", "template", "get", templateName);
         var result = Op(JsonContext.Default.Template, command);
 
         result.Name = templateName;

--- a/OnePassword.NET/OnePasswordManager.Users.cs
+++ b/OnePassword.NET/OnePasswordManager.Users.cs
@@ -10,7 +10,7 @@ public sealed partial class OnePasswordManager
     /// <inheritdoc />
     public ImmutableList<User> GetUsers()
     {
-        const string command = "user list";
+        var command = new OpCommand("user", "list");
         return Op(JsonContext.Default.ImmutableListUser, command);
     }
 
@@ -38,7 +38,7 @@ public sealed partial class OnePasswordManager
         if (groupId is null || groupId.Length == 0)
             throw new ArgumentException($"{nameof(groupId)} cannot be empty.", nameof(groupId));
 
-        var command = $"group user list {groupId}";
+        var command = new OpCommand("group", "user", "list", groupId);
         return Op(JsonContext.Default.ImmutableListGroupUser, command);
     }
 
@@ -48,7 +48,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"vault user list {vaultId}";
+        var command = new OpCommand("vault", "user", "list", vaultId);
         return Op(JsonContext.Default.ImmutableListVaultUser, command);
     }
 
@@ -67,7 +67,7 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"user get {userId}";
+        var command = new OpCommand("user", "get", userId);
         return Op(JsonContext.Default.UserDetails, command);
     }
 
@@ -87,9 +87,9 @@ public sealed partial class OnePasswordManager
         if (trimmedEmailAddress.Length == 0)
             throw new ArgumentException($"{nameof(emailAddress)} cannot be empty.", nameof(emailAddress));
 
-        var command = $"user provision --name \"{trimmedName}\" --email \"{trimmedEmailAddress}\"";
+        var command = new OpCommand("user", "provision", "--name", trimmedName, "--email", trimmedEmailAddress);
         if (language != Language.Default)
-            command += $" --language \"{language.ToEnumString()}\"";
+            command.Add("--language", language.ToEnumString());
         return Op(JsonContext.Default.UserDetails, command);
     }
 
@@ -108,14 +108,14 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"user confirm {userId}";
+        var command = new OpCommand("user", "confirm", userId);
         Op(command);
     }
 
     /// <inheritdoc />
     public void ConfirmAllUsers()
     {
-        const string command = "user confirm --all";
+        var command = new OpCommand("user", "confirm", "--all");
         Op(command);
     }
 
@@ -148,11 +148,11 @@ public sealed partial class OnePasswordManager
         if (name is null && travelMode is null)
             throw new InvalidOperationException("Nothing to edit.");
 
-        var command = $"user edit {userId}";
+        var command = new OpCommand("user", "edit", userId);
         if (trimmedName is not null)
-            command += $" --name \"{trimmedName}\"";
+            command.Add("--name", trimmedName);
         if (travelMode.HasValue)
-            command += $" --travel-mode {(travelMode.Value ? "on" : "off")}";
+            command.Add("--travel-mode", travelMode.Value ? "on" : "off");
         Op(command);
     }
 
@@ -171,7 +171,7 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"user delete {userId}";
+        var command = new OpCommand("user", "delete", userId);
         Op(command);
     }
 
@@ -190,9 +190,9 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"user suspend {userId}";
+        var command = new OpCommand("user", "suspend", userId);
         if (deauthorizeDevicesDelay is not null)
-            command += $" --deauthorize-devices-after {deauthorizeDevicesDelay.Value}s";
+            command.Add("--deauthorize-devices-after", $"{deauthorizeDevicesDelay.Value}s");
         Op(command);
     }
 
@@ -211,7 +211,7 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"user reactivate {userId}";
+        var command = new OpCommand("user", "reactivate", userId);
         Op(command);
     }
 }

--- a/OnePassword.NET/OnePasswordManager.Vaults.cs
+++ b/OnePassword.NET/OnePasswordManager.Vaults.cs
@@ -10,7 +10,7 @@ public sealed partial class OnePasswordManager
     /// <inheritdoc />
     public ImmutableList<Vault> GetVaults()
     {
-        const string command = "vault list";
+        var command = new OpCommand("vault", "list");
         return Op(JsonContext.Default.ImmutableListVault, command);
     }
 
@@ -38,7 +38,7 @@ public sealed partial class OnePasswordManager
         if (groupId is null || groupId.Length == 0)
             throw new ArgumentException($"{nameof(groupId)} cannot be empty.", nameof(groupId));
 
-        var command = $"vault list --group {groupId}";
+        var command = new OpCommand("vault", "list", "--group", groupId);
         return Op(JsonContext.Default.ImmutableListVault, command);
     }
 
@@ -48,7 +48,7 @@ public sealed partial class OnePasswordManager
         if (userId is null || userId.Length == 0)
             throw new ArgumentException($"{nameof(userId)} cannot be empty.", nameof(userId));
 
-        var command = $"vault list --user {userId}";
+        var command = new OpCommand("vault", "list", "--user", userId);
         return Op(JsonContext.Default.ImmutableListVault, command);
     }
 
@@ -67,7 +67,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"vault get {vaultId}";
+        var command = new OpCommand("vault", "get", vaultId);
         return Op(JsonContext.Default.VaultDetails, command);
     }
 
@@ -83,13 +83,13 @@ public sealed partial class OnePasswordManager
 
         var trimmedDescription = description?.Trim();
 
-        var command = $"vault create \"{trimmedName}\"";
+        var command = new OpCommand("vault", "create", trimmedName);
         if (trimmedDescription is not null)
-            command += $" --description \"{trimmedDescription}\"";
+            command.Add("--description", trimmedDescription);
         if (icon != VaultIcon.Default && icon != VaultIcon.Unknown)
-            command += $" --icon \"{icon.ToEnumString()}\"";
+            command.Add("--icon", icon.ToEnumString());
         if (allowAdminsToManage.HasValue)
-            command += $" --allow-admins-to-manage {(allowAdminsToManage.Value ? "true" : "false")}";
+            command.Add("--allow-admins-to-manage", allowAdminsToManage.Value ? "true" : "false");
         return Op(JsonContext.Default.VaultDetails, command);
     }
 
@@ -124,15 +124,15 @@ public sealed partial class OnePasswordManager
         if (name is null && description is null && icon is VaultIcon.Default or VaultIcon.Unknown && travelMode is null)
             throw new InvalidOperationException("Nothing to edit.");
 
-        var command = $"vault edit {vaultId}";
+        var command = new OpCommand("vault", "edit", vaultId);
         if (trimmedName is not null)
-            command += $" --name \"{trimmedName}\"";
+            command.Add("--name", trimmedName);
         if (trimmedDescription is not null)
-            command += $" --description \"{trimmedDescription}\"";
+            command.Add("--description", trimmedDescription);
         if (icon != VaultIcon.Default && icon != VaultIcon.Unknown)
-            command += $" --icon \"{icon.ToEnumString()}\"";
+            command.Add("--icon", icon.ToEnumString());
         if (travelMode.HasValue)
-            command += $" --travel-mode {(travelMode.Value ? "on" : "off")}";
+            command.Add("--travel-mode", travelMode.Value ? "on" : "off");
         Op(command);
     }
 
@@ -151,7 +151,7 @@ public sealed partial class OnePasswordManager
         if (vaultId is null || vaultId.Length == 0)
             throw new ArgumentException($"{nameof(vaultId)} cannot be empty.", nameof(vaultId));
 
-        var command = $"vault delete {vaultId}";
+        var command = new OpCommand("vault", "delete", vaultId);
         Op(command);
     }
 
@@ -191,7 +191,7 @@ public sealed partial class OnePasswordManager
         if (permissions is null || permissions.Count == 0)
             throw new ArgumentException($"{nameof(permissions)} cannot be empty.", nameof(permissions));
 
-        var command = $"vault group grant --vault {vaultId} --group {groupId} --permissions \"{permissions.ToCommaSeparated()}\"";
+        var command = new OpCommand("vault", "group", "grant", "--vault", vaultId, "--group", groupId, "--permissions", permissions.ToCommaSeparated());
         Op(command);
     }
 
@@ -205,7 +205,7 @@ public sealed partial class OnePasswordManager
         if (permissions is null || permissions.Count == 0)
             throw new ArgumentException($"{nameof(permissions)} cannot be empty.", nameof(permissions));
 
-        var command = $"vault user grant --vault {vaultId} --user {userId} --permissions \"{permissions.ToCommaSeparated()}\"";
+        var command = new OpCommand("vault", "user", "grant", "--vault", vaultId, "--user", userId, "--permissions", permissions.ToCommaSeparated());
         Op(command);
     }
 
@@ -245,7 +245,7 @@ public sealed partial class OnePasswordManager
         if (permissions is null || permissions.Count == 0)
             throw new ArgumentException($"{nameof(permissions)} cannot be empty.", nameof(permissions));
 
-        var command = $"vault group revoke --vault {vaultId} --group {groupId} --permissions \"{permissions.ToCommaSeparated()}\"";
+        var command = new OpCommand("vault", "group", "revoke", "--vault", vaultId, "--group", groupId, "--permissions", permissions.ToCommaSeparated());
         Op(command);
     }
 
@@ -259,7 +259,7 @@ public sealed partial class OnePasswordManager
         if (permissions is null || permissions.Count == 0)
             throw new ArgumentException($"{nameof(permissions)} cannot be empty.", nameof(permissions));
 
-        var command = $"vault user revoke --vault {vaultId} --user {userId} --permissions \"{permissions.ToCommaSeparated()}\"";
+        var command = new OpCommand("vault", "user", "revoke", "--vault", vaultId, "--user", userId, "--permissions", permissions.ToCommaSeparated());
         Op(command);
     }
 }

--- a/OnePassword.NET/OnePasswordManager.cs
+++ b/OnePassword.NET/OnePasswordManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -169,6 +169,21 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
         chmod?.WaitForExit();
     }
 
+    private static void ApplyFileMode(string fileMode, string filePath)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        using var chmod = Process.Start(new ProcessStartInfo("chmod", $"{fileMode} \"{filePath}\"")
+        {
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        });
+        chmod?.WaitForExit();
+    }
+
     private static string GetStandardError(Process process)
     {
         var error = new StringBuilder();
@@ -194,12 +209,12 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
         return obj;
     }
 
-    private string Op(string command, string? input = null, bool returnError = false) => Op(command, input is null ? Array.Empty<string>() : [input], returnError);
+    private string Op(string command, string? input = null, bool returnError = false, bool formatOutput = true) => Op(command, input is null ? Array.Empty<string>() : [input], returnError, formatOutput);
 
-    private string Op(string command, IEnumerable<string> input, bool returnError)
+    private string Op(string command, IEnumerable<string> input, bool returnError, bool formatOutput = true)
     {
         var arguments = command;
-        if (command != "--version")
+        if (command != "--version" && formatOutput)
             arguments += " --format json --no-color";
 
         switch (_mode)

--- a/OnePassword.NET/OnePasswordManager.cs
+++ b/OnePassword.NET/OnePasswordManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
@@ -20,12 +21,38 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
 #else
     private static readonly Regex VersionRegex = new (@"Version ([^\s]+) is now available\.", RegexOptions.Compiled);
 #endif
-    private readonly string[] _excludedAccountCommands = ["--version", "update", "account list", "account add", "account forget", "signout --all"];
-    private readonly string[] _excludedSessionCommands = ["--version", "update", "account list", "account add", "account forget", "signin", "signout", "signout --all"];
+    private static readonly string[][] ExcludedAccountCommands =
+    [
+        ["--version"],
+        ["update"],
+        ["account", "list"],
+        ["account", "add"],
+        ["account", "forget"],
+        ["signout", "--all"]
+    ];
+
+    private static readonly string[][] ExcludedSessionCommands =
+    [
+        ["--version"],
+        ["update"],
+        ["account", "list"],
+        ["account", "add"],
+        ["account", "forget"],
+        ["signin"],
+        ["signout"],
+        ["signout", "--all"]
+    ];
+
+    private static readonly string[][] ServiceAccountUnsupportedCommands =
+    [
+        ["events-api"],
+        ["group"],
+        ["user"]
+    ];
+
     private readonly Mode _mode = Mode.Interactive;
     private readonly string _opPath;
     private readonly string _serviceAccountToken;
-    private readonly string[] _serviceAccountUnsupportedCommands = ["events-api", "group", "user"];
     private readonly bool _verbose;
     private string _account = "";
     private string _session = "";
@@ -70,7 +97,7 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
         var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         Directory.CreateDirectory(tempDirectory);
 
-        var command = $"update --directory \"{tempDirectory}\"";
+        var command = new OpCommand("update", "--directory", tempDirectory);
         var result = Op(command);
 
         var match = VersionRegex.Match(result);
@@ -106,7 +133,7 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
         if (trimmedReference.Length == 0)
             throw new ArgumentException($"{nameof(trimmedReference)} cannot be empty.", nameof(reference));
 
-        var command = $"read {trimmedReference} --no-newline";
+        var command = new OpCommand("read", trimmedReference, "--no-newline");
         return Op(command);
     }
 
@@ -125,9 +152,9 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
             throw new ArgumentException($"{nameof(trimmedFilePath)} cannot be empty.", nameof(filePath));
 
         var trimmedFileMode = fileMode?.Trim();
-        var command = $"read {trimmedReference} --no-newline --force --out-file \"{trimmedFilePath}\"";
+        var command = new OpCommand("read", trimmedReference, "--no-newline", "--force", "--out-file", trimmedFilePath);
         if (trimmedFileMode is not null && trimmedFileMode.Length > 0)
-            command += $" --file-mode {trimmedFileMode}";
+            command.Add("--file-mode", trimmedFileMode);
         Op(command);
     }
 
@@ -150,7 +177,7 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
 
     private string GetVersion()
     {
-        const string command = "--version";
+        var command = new OpCommand("--version");
         return Op(command).Trim();
     }
 
@@ -200,7 +227,7 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
         return output.ToString();
     }
 
-    private TResult Op<TResult>(JsonTypeInfo<TResult> jsonTypeInfo, string command, string? input = null, bool returnError = false) where TResult : class
+    private TResult Op<TResult>(JsonTypeInfo<TResult> jsonTypeInfo, OpCommand command, string? input = null, bool returnError = false) where TResult : class
     {
         var result = Op(command, input is null ? Array.Empty<string>() : [input], returnError);
         var obj = JsonSerializer.Deserialize(result, jsonTypeInfo) ?? throw new SerializationException("Could not deserialize the command result.");
@@ -209,44 +236,44 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
         return obj;
     }
 
-    private string Op(string command, string? input = null, bool returnError = false, bool formatOutput = true) => Op(command, input is null ? Array.Empty<string>() : [input], returnError, formatOutput);
+    private string Op(OpCommand command, string? input = null, bool returnError = false, bool formatOutput = true) => Op(command, input is null ? Array.Empty<string>() : [input], returnError, formatOutput);
 
-    private string Op(string command, IEnumerable<string> input, bool returnError, bool formatOutput = true)
+    private string Op(OpCommand command, IEnumerable<string> input, bool returnError, bool formatOutput = true)
     {
-        var arguments = command;
-        if (command != "--version" && formatOutput)
-            arguments += " --format json --no-color";
+        var arguments = command.Clone();
+        if (!command.StartsWith(["--version"]) && formatOutput)
+            arguments.Add("--format", "json", "--no-color");
 
         switch (_mode)
         {
             case Mode.ServiceAccount:
-                if (IsUnsupportedCommand(command, _serviceAccountUnsupportedCommands))
+                if (IsCommandMatch(command, ServiceAccountUnsupportedCommands))
                     throw new InvalidOperationException($"Unsupported command {command} when using ServiceAccount");
                 break;
             case Mode.Interactive:
             case Mode.AppIntegrated:
             default:
-                var excluded = IsExcludedCommand(command, _excludedAccountCommands);
+                var excluded = IsCommandMatch(command, ExcludedAccountCommands);
                 var requireAccount = _mode != Mode.AppIntegrated && !excluded;
                 var passAccount = _account.Length != 0 && !excluded;
                 if (requireAccount && !passAccount)
                     throw new InvalidOperationException("Cannot execute command because account has not been set.");
 
-                var passSession = !(_mode == Mode.AppIntegrated || IsExcludedCommand(command, _excludedSessionCommands));
+                var passSession = !(_mode == Mode.AppIntegrated || IsCommandMatch(command, ExcludedSessionCommands));
                 if (passSession && _session.Length == 0)
                     throw new InvalidOperationException("Cannot execute command because account has not been signed in.");
 
                 if (passAccount)
-                    arguments += $" --account {_account}";
+                    arguments.Add("--account", _account);
                 if (passSession)
-                    arguments += $" --session {_session}";
+                    arguments.Add("--session", _session);
                 break;
         }
 
         if (_verbose)
             Console.WriteLine($"{Path.GetDirectoryName(_opPath)}>op {arguments}");
 
-        var startInfo = new ProcessStartInfo(_opPath, arguments)
+        var startInfo = new ProcessStartInfo(_opPath)
         {
             CreateNoWindow = true,
             UseShellExecute = false,
@@ -256,6 +283,15 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
             StandardOutputEncoding = Encoding.UTF8,
             StandardErrorEncoding = Encoding.UTF8
         };
+        if (IsWindowsCommandScript(_opPath))
+        {
+            startInfo.Arguments = arguments.ToString();
+        }
+        else
+        {
+            foreach (var argument in arguments)
+                startInfo.ArgumentList.Add(argument);
+        }
 
         if (_mode == Mode.ServiceAccount)
             startInfo.EnvironmentVariables["OP_SERVICE_ACCOUNT_TOKEN"] = _serviceAccountToken;
@@ -294,14 +330,59 @@ public sealed partial class OnePasswordManager : IOnePasswordManager
         throw new InvalidOperationException(error.Length > 28 ? error[28..].Trim() : error);
     }
 
-    private static bool IsExcludedCommand(string command, IEnumerable<string> excludedCommands)
+    private static bool IsCommandMatch(OpCommand command, IEnumerable<IReadOnlyList<string>> commandPrefixes)
     {
-        return excludedCommands.Any(x => command.StartsWith(x, StringComparison.InvariantCulture));
+        return commandPrefixes.Any(command.StartsWith);
     }
 
-    private static bool IsUnsupportedCommand(string command, IEnumerable<string> unsupportedCommands)
+    private static bool IsWindowsCommandScript(string filePath)
     {
-        return unsupportedCommands.Any(x => command.StartsWith(x, StringComparison.InvariantCulture));
+        var extension = Path.GetExtension(filePath);
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+               && (string.Equals(extension, ".cmd", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(extension, ".bat", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class OpCommand : IEnumerable<string>
+    {
+        private readonly List<string> _arguments;
+
+        public OpCommand(params string[] arguments)
+        {
+            _arguments = [.. arguments];
+        }
+
+        private OpCommand(IEnumerable<string> arguments)
+        {
+            _arguments = [.. arguments];
+        }
+
+        public OpCommand Add(params string[] arguments)
+        {
+            _arguments.AddRange(arguments);
+            return this;
+        }
+
+        public OpCommand Clone() => new(_arguments);
+
+        public IEnumerator<string> GetEnumerator() => _arguments.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public bool StartsWith(IReadOnlyList<string> prefix)
+        {
+            return prefix.Count <= _arguments.Count
+                   && prefix.Select((argument, index) => string.Equals(argument, _arguments[index], StringComparison.Ordinal)).All(static matches => matches);
+        }
+
+        public override string ToString() => string.Join(" ", _arguments.Select(FormatArgument));
+
+        private static string FormatArgument(string argument)
+        {
+            return argument.Any(char.IsWhiteSpace) || argument.Contains('"', StringComparison.Ordinal)
+                ? $"\"{argument.Replace("\"", "\\\"", StringComparison.Ordinal)}\""
+                : argument;
+        }
     }
 #if NET7_0_OR_GREATER
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ var attachment = itemWithAttachments.FileAttachments.First();
 onePassword.SaveFileAttachmentContent(attachment, itemWithAttachments, vault, @"C:\Files\Production.env");
 ```
 
+### Reading variables from a 1Password Environment
+
+This feature requires the beta 1Password CLI `2.33.0-beta.02` or later.
+
+```csharp
+var variables = onePassword.GetEnvironmentVariables("environment-id");
+
+foreach (var variable in variables)
+    Console.WriteLine($"{variable.Name}={variable.Value}");
+```
+
+### Saving variables from a 1Password Environment
+
+This writes the Environment output to disk using the same `KEY=value` format returned by the CLI.
+
+```csharp
+onePassword.SaveEnvironmentVariables("environment-id", @".env");
+```
+
 ### Sharing an item without email restrictions
 
 ```csharp

--- a/docfx/docs/quick-start.md
+++ b/docfx/docs/quick-start.md
@@ -141,6 +141,25 @@ var attachment = itemWithAttachments.FileAttachments.First();
 onePassword.SaveFileAttachmentContent(attachment, itemWithAttachments, vault, @"C:\Files\Production.env");
 ```
 
+### Reading variables from a 1Password Environment
+
+This feature requires the beta 1Password CLI `2.33.0-beta.02` or later.
+
+```csharp
+var variables = onePassword.GetEnvironmentVariables("environment-id");
+
+foreach (var variable in variables)
+    Console.WriteLine($"{variable.Name}={variable.Value}");
+```
+
+### Saving variables from a 1Password Environment
+
+This writes the Environment output to disk using the same `KEY=value` format returned by the CLI.
+
+```csharp
+onePassword.SaveEnvironmentVariables("environment-id", @".env");
+```
+
 ### Sharing an item without email restrictions
 
 ```csharp


### PR DESCRIPTION
Resolves https://github.com/jscarle/OnePassword.NET/issues/104.

Adds the ability read variables from 1password's new Environments beta feature.

Open questions:
1. Do you have any reservations against adding API surfaces against beta features?
2. The `ApplyFileMode` behavior feels a bit hacky. The user could adjust file perms after the call if they need that.